### PR TITLE
Add floating WhatsApp button to home page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -35,3 +35,22 @@ footer {
 .badge {
     font-size: 14px;
 }
+
+/* WhatsApp floating button */
+.whatsapp-btn {
+    position: fixed;
+    left: 20px;
+    bottom: 20px;
+    background-color: #25D366;
+    color: white;
+    border-radius: 50%;
+    width: 50px;
+    height: 50px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+    text-decoration: none;
+    box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.3);
+    z-index: 1000;
+}

--- a/index.html
+++ b/index.html
@@ -83,7 +83,10 @@
     <footer class="bg-dark text-white text-center py-3">
         <p>&copy; 2025 Joyería Brillante. Todos los derechos reservados.</p>
     </footer>
-
+    <!-- WhatsApp Floating Button -->
+    <a href="https://wa.me/50255555555" class="whatsapp-btn" target="_blank" aria-label="Contactar por WhatsApp">
+        <i class="fab fa-whatsapp"></i>
+    </a>
 
     <!-- Bootstrap JS -->
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>


### PR DESCRIPTION
## Summary
- add fixed WhatsApp contact button on the home page
- style the button with a green circular design and bottom-left positioning

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898c0b503f08325b990c81481ae64e1