### PR TITLE
Integrate map and email contact form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -15,18 +15,18 @@
 
         <div class="row">
             <div class="col-md-6">
-                <form id="contact-form">
+                <form id="contact-form" action="https://formsubmit.co/fjorgemario4@gmail.com" method="POST">
                     <div class="form-group">
                         <label>Nombre completo</label>
-                        <input type="text" class="form-control" required>
+                        <input type="text" class="form-control" name="name" required>
                     </div>
                     <div class="form-group">
                         <label>Correo electrónico</label>
-                        <input type="email" class="form-control" required>
+                        <input type="email" class="form-control" name="email" required>
                     </div>
                     <div class="form-group">
                         <label>Mensaje</label>
-                        <textarea class="form-control" rows="5" required></textarea>
+                        <textarea class="form-control" rows="5" name="message" required></textarea>
                     </div>
                     <button type="submit" class="btn btn-primary">Enviar mensaje</button>
                 </form>
@@ -39,15 +39,12 @@
                 <p>También puedes encontrarnos en nuestras redes sociales.</p>
             </div>
         </div>
-    </div>
 
-    <!-- Script de envío simulado -->
-    <script>
-        document.getElementById("contact-form").addEventListener("submit", function (e) {
-            e.preventDefault();
-            alert("¡Gracias por tu mensaje! Nos pondremos en contacto pronto.");
-            this.reset();
-        });
-    </script>
+        <div class="row mt-4">
+            <div class="col-12">
+                <iframe src="https://maps.google.com/maps?q=14.6318104,-90.6090869&z=15&output=embed" width="100%" height="400" frameborder="0" style="border:0;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe>
+            </div>
+        </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- embed company location map on contact page
- send contact form submissions to fjorgemario4@gmail.com via Formsubmit

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898e59784e483259649f9aaeb9d7788