### PR TITLE
Add executive financial dashboard with sales data

### DIFF
--- a/dashboard-financiero.html
+++ b/dashboard-financiero.html
@@ -1,0 +1,892 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard Financiero Ejecutivo</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js" integrity="sha512-jmVdQIeHXO8dY/95B2S/bRMyCV2wAPOQgpdnXl16rDpD+s/COM24kTx5cDIeEJD7BqXc9E+u6KDAdAm8YGXcqw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+            color: #333;
+            min-height: 100vh;
+        }
+
+        .header {
+            background: rgba(255, 255, 255, 0.95);
+            backdrop-filter: blur(15px);
+            padding: 25px;
+            text-align: center;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+            border-bottom: 3px solid #667eea;
+        }
+
+        .header h1 {
+            color: #1e3c72;
+            font-size: 2.8rem;
+            margin-bottom: 10px;
+            font-weight: 800;
+            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+        }
+
+        .header p {
+            color: #666;
+            font-size: 1.2rem;
+            font-weight: 500;
+        }
+
+        .controls {
+            background: rgba(255, 255, 255, 0.9);
+            backdrop-filter: blur(10px);
+            padding: 25px;
+            margin: 20px;
+            border-radius: 20px;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+            border: 1px solid rgba(255, 255, 255, 0.3);
+        }
+
+        .filters {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 20px;
+            margin-bottom: 20px;
+        }
+
+        .filter-group {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .filter-group label {
+            font-weight: 700;
+            margin-bottom: 8px;
+            color: #1e3c72;
+            font-size: 0.95rem;
+        }
+
+        select, input {
+            padding: 12px;
+            border: 2px solid #e1e8ed;
+            border-radius: 12px;
+            font-size: 14px;
+            transition: all 0.3s ease;
+            background: white;
+            font-weight: 500;
+        }
+
+        select:focus, input:focus {
+            outline: none;
+            border-color: #667eea;
+            box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+            transform: translateY(-1px);
+        }
+
+        .action-buttons {
+            display: flex;
+            gap: 15px;
+            justify-content: center;
+            flex-wrap: wrap;
+        }
+
+        .btn {
+            padding: 12px 24px;
+            border: none;
+            border-radius: 12px;
+            font-size: 14px;
+            font-weight: 700;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .btn-primary {
+            background: linear-gradient(45deg, #667eea, #764ba2);
+            color: white;
+        }
+
+        .btn-secondary {
+            background: linear-gradient(45deg, #f093fb, #f5576c);
+            color: white;
+        }
+
+        .btn:hover {
+            transform: translateY(-3px);
+            box-shadow: 0 10px 25px rgba(102, 126, 234, 0.3);
+        }
+
+        .kpi-container {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 25px;
+            margin: 25px;
+        }
+
+        .kpi-card {
+            background: rgba(255, 255, 255, 0.95);
+            backdrop-filter: blur(15px);
+            padding: 30px;
+            border-radius: 20px;
+            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
+            text-align: center;
+            transition: all 0.3s ease;
+            border: 1px solid rgba(255, 255, 255, 0.3);
+            position: relative;
+            overflow: hidden;
+        }
+
+        .kpi-card::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 4px;
+            background: linear-gradient(45deg, #667eea, #764ba2);
+        }
+
+        .kpi-card:hover {
+            transform: translateY(-8px);
+            box-shadow: 0 20px 50px rgba(0, 0, 0, 0.15);
+        }
+
+        .kpi-value {
+            font-size: 2.5rem;
+            font-weight: 900;
+            margin-bottom: 10px;
+            background: linear-gradient(45deg, #1e3c72, #2a5298);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        .kpi-label {
+            font-size: 1.1rem;
+            color: #666;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .kpi-change {
+            margin-top: 8px;
+            font-size: 0.9rem;
+            font-weight: 600;
+        }
+
+        .positive { color: #27ae60; }
+        .negative { color: #e74c3c; }
+
+        .charts-container {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
+            gap: 25px;
+            margin: 25px;
+        }
+
+        .chart-card {
+            background: rgba(255, 255, 255, 0.95);
+            backdrop-filter: blur(15px);
+            padding: 30px;
+            border-radius: 20px;
+            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
+            border: 1px solid rgba(255, 255, 255, 0.3);
+            transition: all 0.3s ease;
+        }
+
+        .chart-card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 15px 45px rgba(0, 0, 0, 0.15);
+        }
+
+        .chart-title {
+            font-size: 1.6rem;
+            font-weight: 700;
+            color: #1e3c72;
+            margin-bottom: 25px;
+            text-align: center;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+
+        .chart-container {
+            position: relative;
+            height: 400px;
+        }
+
+        .insights-section {
+            margin: 25px;
+            background: rgba(255, 255, 255, 0.95);
+            backdrop-filter: blur(15px);
+            padding: 35px;
+            border-radius: 20px;
+            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
+            border: 1px solid rgba(255, 255, 255, 0.3);
+        }
+
+        .insights-title {
+            font-size: 1.8rem;
+            font-weight: 800;
+            color: #1e3c72;
+            margin-bottom: 25px;
+            text-align: center;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+
+        .insight-item {
+            background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+            padding: 20px;
+            margin: 15px 0;
+            border-radius: 15px;
+            border-left: 5px solid #667eea;
+            font-weight: 500;
+            box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+            transition: all 0.3s ease;
+        }
+
+        .insight-item:hover {
+            transform: translateX(5px);
+            box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+        }
+
+        .loading {
+            text-align: center;
+            padding: 50px;
+            font-size: 1.2rem;
+            color: #666;
+        }
+
+        .data-count {
+            background: #667eea;
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            font-weight: 600;
+            display: inline-block;
+            margin-left: 10px;
+        }
+
+        @media (max-width: 768px) {
+            .charts-container {
+                grid-template-columns: 1fr;
+            }
+            
+            .filters {
+                grid-template-columns: 1fr;
+            }
+            
+            .header h1 {
+                font-size: 2.2rem;
+            }
+            
+            .kpi-value {
+                font-size: 2rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>📊 Dashboard Financiero Ejecutivo</h1>
+        <p>Análisis Integral de Performance Comercial y Rentabilidad</p>
+    </div>
+
+    <div class="controls">
+        <div class="filters">
+            <div class="filter-group">
+                <label for="segmentFilter">Segmento de Mercado:</label>
+                <select id="segmentFilter">
+                    <option value="all">Todos los Segmentos</option>
+                </select>
+            </div>
+            <div class="filter-group">
+                <label for="countryFilter">País:</label>
+                <select id="countryFilter">
+                    <option value="all">Todos los Países</option>
+                </select>
+            </div>
+            <div class="filter-group">
+                <label for="productFilter">Producto:</label>
+                <select id="productFilter">
+                    <option value="all">Todos los Productos</option>
+                </select>
+            </div>
+            <div class="filter-group">
+                <label for="yearFilter">Año:</label>
+                <select id="yearFilter">
+                    <option value="all">Todos los Años</option>
+                </select>
+            </div>
+            <div class="filter-group">
+                <label for="discountFilter">Banda de Descuento:</label>
+                <select id="discountFilter">
+                    <option value="all">Todas las Bandas</option>
+                </select>
+            </div>
+            <div class="filter-group">
+                <label for="monthFilter">Mes:</label>
+                <select id="monthFilter">
+                    <option value="all">Todos los Meses</option>
+                </select>
+            </div>
+        </div>
+        <div class="action-buttons">
+            <button class="btn btn-primary" onclick="resetFilters()">🔄 Restablecer Filtros</button>
+            <button class="btn btn-secondary" onclick="exportData()">📊 Exportar Datos</button>
+        </div>
+        <div style="text-align: center; margin-top: 15px;">
+            <span>Registros mostrados: <span class="data-count" id="recordCount">0</span></span>
+        </div>
+    </div>
+
+    <div class="kpi-container">
+        <div class="kpi-card">
+            <div class="kpi-value" id="totalSales">$0</div>
+            <div class="kpi-label">Ventas Totales</div>
+            <div class="kpi-change" id="salesChange">—</div>
+        </div>
+        <div class="kpi-card">
+            <div class="kpi-value" id="totalProfit">$0</div>
+            <div class="kpi-label">Utilidad Total</div>
+            <div class="kpi-change" id="profitChange">—</div>
+        </div>
+        <div class="kpi-card">
+            <div class="kpi-value" id="profitMargin">0%</div>
+            <div class="kpi-label">Margen de Utilidad</div>
+            <div class="kpi-change" id="marginChange">—</div>
+        </div>
+        <div class="kpi-card">
+            <div class="kpi-value" id="totalUnits">0</div>
+            <div class="kpi-label">Unidades Vendidas</div>
+            <div class="kpi-change" id="unitsChange">—</div>
+        </div>
+        <div class="kpi-card">
+            <div class="kpi-value" id="avgSalePrice">$0</div>
+            <div class="kpi-label">Precio Promedio</div>
+            <div class="kpi-change" id="priceChange">—</div>
+        </div>
+        <div class="kpi-card">
+            <div class="kpi-value" id="totalDiscounts">$0</div>
+            <div class="kpi-label">Descuentos Totales</div>
+            <div class="kpi-change" id="discountChange">—</div>
+        </div>
+    </div>
+
+    <div class="charts-container">
+        <div class="chart-card">
+            <div class="chart-title">💰 Ventas por Segmento</div>
+            <div class="chart-container">
+                <canvas id="segmentChart"></canvas>
+            </div>
+        </div>
+        <div class="chart-card">
+            <div class="chart-title">🌍 Performance por País</div>
+            <div class="chart-container">
+                <canvas id="countryChart"></canvas>
+            </div>
+        </div>
+        <div class="chart-card">
+            <div class="chart-title">📦 Análisis de Productos</div>
+            <div class="chart-container">
+                <canvas id="productChart"></canvas>
+            </div>
+        </div>
+        <div class="chart-card">
+            <div class="chart-title">📈 Tendencia Mensual</div>
+            <div class="chart-container">
+                <canvas id="monthlyChart"></canvas>
+            </div>
+        </div>
+        <div class="chart-card">
+            <div class="chart-title">💸 Impacto de Descuentos</div>
+            <div class="chart-container">
+                <canvas id="discountChart"></canvas>
+            </div>
+        </div>
+        <div class="chart-card">
+            <div class="chart-title">🎯 Rentabilidad por Segmento</div>
+            <div class="chart-container">
+                <canvas id="profitabilityChart"></canvas>
+            </div>
+        </div>
+    </div>
+
+    <div class="insights-section">
+        <h3 class="insights-title">🔍 Insights Estratégicos</h3>
+        <div id="insightsContainer">
+            <div class="loading">Generando análisis inteligente...</div>
+        </div>
+    </div>
+
+    <script>
+        const rawData = [
+            { segment: "Government", country: "Canada", product: "Carretera", discountBand: "None", unitsSold: 1618.5, manufacturingPrice: 3, salePrice: 20, grossSales: 32370, discounts: 0, sales: 32370, cogs: 16185, profit: 16185, date: "2014-01-01", monthNumber: 1, monthName: "January", year: 2014 },
+            { segment: "Government", country: "Germany", product: "Carretera", discountBand: "None", unitsSold: 1321, manufacturingPrice: 3, salePrice: 20, grossSales: 26420, discounts: 0, sales: 26420, cogs: 13210, profit: 13210, date: "2014-01-01", monthNumber: 1, monthName: "January", year: 2014 },
+            { segment: "Midmarket", country: "France", product: "Carretera", discountBand: "None", unitsSold: 2178, manufacturingPrice: 3, salePrice: 15, grossSales: 32670, discounts: 0, sales: 32670, cogs: 21780, profit: 10890, date: "2014-06-01", monthNumber: 6, monthName: "June", year: 2014 },
+            { segment: "Government", country: "Germany", product: "Carretera", discountBand: "None", unitsSold: 1513, manufacturingPrice: 3, salePrice: 350, grossSales: 529550, discounts: 0, sales: 529550, cogs: 393380, profit: 136170, date: "2014-12-01", monthNumber: 12, monthName: "December", year: 2014 },
+            { segment: "Small Business", country: "United States of America", product: "Montana", discountBand: "Low", unitsSold: 2301, manufacturingPrice: 5, salePrice: 300, grossSales: 690300, discounts: 6903, sales: 683397, cogs: 575250, profit: 108147, date: "2014-04-01", monthNumber: 4, monthName: "April", year: 2014 },
+            { segment: "Government", country: "France", product: "Montana", discountBand: "Medium", unitsSold: 1384.5, manufacturingPrice: 5, salePrice: 350, grossSales: 484575, discounts: 24228.75, sales: 460346.25, cogs: 359970, profit: 100376.25, date: "2014-01-01", monthNumber: 1, monthName: "January", year: 2014 },
+            { segment: "Small Business", country: "United States of America", product: "Carretera", discountBand: "High", unitsSold: 3495, manufacturingPrice: 3, salePrice: 300, grossSales: 1048500, discounts: 125820, sales: 922680, cogs: 873750, profit: 48930, date: "2014-01-01", monthNumber: 1, monthName: "January", year: 2014 },
+            { segment: "Channel Partners", country: "Canada", product: "Montana", discountBand: "None", unitsSold: 2518, manufacturingPrice: 5, salePrice: 12, grossSales: 30216, discounts: 0, sales: 30216, cogs: 7554, profit: 22662, date: "2014-06-01", monthNumber: 6, monthName: "June", year: 2014 },
+            { segment: "Government", country: "France", product: "Montana", discountBand: "None", unitsSold: 1899, manufacturingPrice: 5, salePrice: 20, grossSales: 37980, discounts: 0, sales: 37980, cogs: 18990, profit: 18990, date: "2014-06-01", monthNumber: 6, monthName: "June", year: 2014 },
+            { segment: "Government", country: "France", product: "Amarilla", discountBand: "None", unitsSold: 2750, manufacturingPrice: 260, salePrice: 350, grossSales: 962500, discounts: 0, sales: 962500, cogs: 715000, profit: 247500, date: "2014-02-01", monthNumber: 2, monthName: "February", year: 2014 },
+            { segment: "Enterprise", country: "Germany", product: "Amarilla", discountBand: "None", unitsSold: 4219.5, manufacturingPrice: 260, salePrice: 125, grossSales: 527437.5, discounts: 0, sales: 527437.5, cogs: 506340, profit: 21097.5, date: "2014-04-01", monthNumber: 4, monthName: "April", year: 2014 },
+            { segment: "Small Business", country: "Canada", product: "VTT", discountBand: "None", unitsSold: 2001, manufacturingPrice: 250, salePrice: 300, grossSales: 600300, discounts: 0, sales: 600300, cogs: 500250, profit: 100050, date: "2014-02-01", monthNumber: 2, monthName: "February", year: 2014 },
+            { segment: "Government", country: "France", product: "VTT", discountBand: "None", unitsSold: 1527, manufacturingPrice: 250, salePrice: 350, grossSales: 534450, discounts: 0, sales: 534450, cogs: 397020, profit: 137430, date: "2013-09-01", monthNumber: 9, monthName: "September", year: 2013 },
+            { segment: "Small Business", country: "France", product: "VTT", discountBand: "None", unitsSold: 2151, manufacturingPrice: 250, salePrice: 300, grossSales: 645300, discounts: 0, sales: 645300, cogs: 537750, profit: 107550, date: "2014-09-01", monthNumber: 9, monthName: "September", year: 2014 },
+            { segment: "Enterprise", country: "Mexico", product: "Carretera", discountBand: "None", unitsSold: 2850, manufacturingPrice: 3, salePrice: 125, grossSales: 356250, discounts: 0, sales: 356250, cogs: 342000, profit: 14250, date: "2014-05-01", monthNumber: 5, monthName: "May", year: 2014 },
+            { segment: "Small Business", country: "Germany", product: "Paseo", discountBand: "Low", unitsSold: 1750, manufacturingPrice: 10, salePrice: 300, grossSales: 525000, discounts: 5250, sales: 519750, cogs: 437500, profit: 82250, date: "2014-08-01", monthNumber: 8, monthName: "August", year: 2014 },
+            { segment: "Channel Partners", country: "United States of America", product: "Montana", discountBand: "Medium", unitsSold: 3200, manufacturingPrice: 5, salePrice: 12, grossSales: 38400, discounts: 2304, sales: 36096, cogs: 9600, profit: 26496, date: "2014-07-01", monthNumber: 7, monthName: "July", year: 2014 },
+            { segment: "Government", country: "France", product: "Velo", discountBand: "High", unitsSold: 2100, manufacturingPrice: 120, salePrice: 350, grossSales: 735000, discounts: 73500, sales: 661500, cogs: 514800, profit: 146700, date: "2014-11-01", monthNumber: 11, monthName: "November", year: 2014 }
+        ];
+
+        let allData = [...rawData];
+        let filteredData = [...allData];
+        let charts = {};
+        let previousMetrics = {};
+
+        document.addEventListener('DOMContentLoaded', () => {
+            initializeFilters();
+            updateDashboard();
+        });
+
+        function formatCurrency(value) {
+            return new Intl.NumberFormat('es-ES', {
+                style: 'currency',
+                currency: 'USD',
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 0
+            }).format(value || 0);
+        }
+
+        function formatNumber(value) {
+            return new Intl.NumberFormat('es-ES').format(Math.round(value || 0));
+        }
+
+        function initializeFilters() {
+            populateSelect('segmentFilter', getUniqueValues(allData, 'segment'));
+            populateSelect('countryFilter', getUniqueValues(allData, 'country'));
+            populateSelect('productFilter', getUniqueValues(allData, 'product'));
+            populateSelect('yearFilter', getUniqueValues(allData, 'year'));
+            populateSelect('discountFilter', getUniqueValues(allData, 'discountBand'));
+            populateSelect('monthFilter', getUniqueValues(allData, 'monthName'));
+
+            ['segmentFilter', 'countryFilter', 'productFilter', 'yearFilter', 'discountFilter', 'monthFilter'].forEach(id => {
+                document.getElementById(id).addEventListener('change', applyFilters);
+            });
+        }
+
+        function getUniqueValues(data, field) {
+            return [...new Set(data.map(item => item[field]).filter(Boolean))].sort((a, b) => {
+                if (typeof a === 'number' && typeof b === 'number') return a - b;
+                return a.localeCompare(b);
+            });
+        }
+
+        function populateSelect(selectId, options) {
+            const select = document.getElementById(selectId);
+            options.forEach(option => {
+                const optionElement = document.createElement('option');
+                optionElement.value = option;
+                optionElement.textContent = option;
+                select.appendChild(optionElement);
+            });
+        }
+
+        function applyFilters() {
+            const filters = {
+                segment: document.getElementById('segmentFilter').value,
+                country: document.getElementById('countryFilter').value,
+                product: document.getElementById('productFilter').value,
+                year: document.getElementById('yearFilter').value,
+                discountBand: document.getElementById('discountFilter').value,
+                month: document.getElementById('monthFilter').value
+            };
+
+            filteredData = allData.filter(row => (
+                (filters.segment === 'all' || row.segment === filters.segment) &&
+                (filters.country === 'all' || row.country === filters.country) &&
+                (filters.product === 'all' || row.product === filters.product) &&
+                (filters.year === 'all' || row.year.toString() === filters.year) &&
+                (filters.discountBand === 'all' || row.discountBand === filters.discountBand) &&
+                (filters.month === 'all' || row.monthName === filters.month)
+            ));
+
+            updateDashboard();
+        }
+
+        function resetFilters() {
+            ['segmentFilter', 'countryFilter', 'productFilter', 'yearFilter', 'discountFilter', 'monthFilter'].forEach(id => {
+                document.getElementById(id).value = 'all';
+            });
+            applyFilters();
+        }
+
+        function updateDashboard() {
+            updateKPIs();
+            updateCharts();
+            generateInsights();
+            updateRecordCount();
+        }
+
+        function updateRecordCount() {
+            document.getElementById('recordCount').textContent = filteredData.length;
+        }
+
+        function updateKPIs() {
+            const totals = filteredData.reduce((acc, row) => {
+                acc.sales += row.sales || 0;
+                acc.profit += row.profit || 0;
+                acc.units += row.unitsSold || 0;
+                acc.discounts += row.discounts || 0;
+                return acc;
+            }, { sales: 0, profit: 0, units: 0, discounts: 0 });
+
+            const profitMargin = totals.sales > 0 ? (totals.profit / totals.sales * 100) : 0;
+            const avgSalePrice = totals.units > 0 ? (totals.sales / totals.units) : 0;
+
+            document.getElementById('totalSales').textContent = formatCurrency(totals.sales);
+            document.getElementById('totalProfit').textContent = formatCurrency(totals.profit);
+            document.getElementById('profitMargin').textContent = profitMargin.toFixed(1) + '%';
+            document.getElementById('totalUnits').textContent = formatNumber(totals.units);
+            document.getElementById('avgSalePrice').textContent = formatCurrency(avgSalePrice);
+            document.getElementById('totalDiscounts').textContent = formatCurrency(totals.discounts);
+
+            updateKPIChanges({
+                sales: totals.sales,
+                profit: totals.profit,
+                margin: profitMargin,
+                units: totals.units,
+                avgPrice: avgSalePrice,
+                discounts: totals.discounts
+            });
+        }
+
+        function updateKPIChanges(currentMetrics) {
+            const config = [
+                { key: 'sales', elementId: 'salesChange', isPercentage: false },
+                { key: 'profit', elementId: 'profitChange', isPercentage: false },
+                { key: 'margin', elementId: 'marginChange', isPercentage: true },
+                { key: 'units', elementId: 'unitsChange', isPercentage: false },
+                { key: 'avgPrice', elementId: 'priceChange', isPercentage: false },
+                { key: 'discounts', elementId: 'discountChange', isPercentage: false }
+            ];
+
+            config.forEach(({ key, elementId, isPercentage }) => {
+                const element = document.getElementById(elementId);
+                const previous = previousMetrics[key];
+                const current = currentMetrics[key];
+
+                if (previous === undefined) {
+                    element.textContent = '—';
+                    element.className = 'kpi-change';
+                    return;
+                }
+
+                const difference = current - previous;
+                const base = isPercentage ? previous : previous !== 0 ? previous : null;
+                const percentageChange = base ? (difference / base) * 100 : 0;
+                const direction = difference >= 0 ? '↑' : '↓';
+                const className = difference >= 0 ? 'kpi-change positive' : 'kpi-change negative';
+
+                if (isPercentage) {
+                    element.textContent = `${direction} ${difference.toFixed(1)} pts`;
+                } else {
+                    element.textContent = `${direction} ${formatNumber(Math.abs(difference))} (${percentageChange.toFixed(1)}%)`;
+                }
+
+                element.className = className;
+            });
+
+            previousMetrics = { ...currentMetrics };
+        }
+
+        function updateCharts() {
+            const palette = ['#667eea', '#764ba2', '#f093fb', '#f5576c', '#43cea2', '#185a9d', '#ff9a9e', '#fad0c4', '#36d1dc', '#5b86e5'];
+
+            const segmentAggregation = aggregateByKey(filteredData, 'segment');
+            const segmentLabels = Object.keys(segmentAggregation);
+            const segmentSales = segmentLabels.map(label => segmentAggregation[label].sales);
+            renderChart('segmentChart', 'bar', {
+                labels: segmentLabels,
+                datasets: [{
+                    label: 'Ventas',
+                    data: segmentSales,
+                    backgroundColor: segmentLabels.map((_, index) => palette[index % palette.length]),
+                    borderRadius: 12
+                }]
+            }, {
+                plugins: { legend: { display: false } },
+                scales: {
+                    y: { beginAtZero: true, ticks: { callback: value => formatCurrency(value) } },
+                    x: { ticks: { font: { size: 12 } } }
+                }
+            });
+
+            const countryAggregation = aggregateByKey(filteredData, 'country');
+            const countryLabels = Object.keys(countryAggregation);
+            const countrySales = countryLabels.map(label => countryAggregation[label].sales);
+            const countryProfit = countryLabels.map(label => countryAggregation[label].profit);
+            renderChart('countryChart', 'bar', {
+                labels: countryLabels,
+                datasets: [
+                    {
+                        label: 'Ventas',
+                        data: countrySales,
+                        backgroundColor: 'rgba(102, 126, 234, 0.7)',
+                        borderColor: '#667eea',
+                        borderWidth: 1
+                    },
+                    {
+                        label: 'Utilidad',
+                        data: countryProfit,
+                        backgroundColor: 'rgba(67, 206, 162, 0.7)',
+                        borderColor: '#43cea2',
+                        borderWidth: 1
+                    }
+                ]
+            }, {
+                responsive: true,
+                scales: {
+                    y: { beginAtZero: true, ticks: { callback: value => formatCurrency(value) } },
+                    x: { ticks: { font: { size: 12 } } }
+                }
+            });
+
+            const productAggregation = aggregateByKey(filteredData, 'product');
+            const productLabels = Object.keys(productAggregation);
+            const productProfit = productLabels.map(label => productAggregation[label].profit);
+            renderChart('productChart', 'doughnut', {
+                labels: productLabels,
+                datasets: [{
+                    label: 'Utilidad',
+                    data: productProfit,
+                    backgroundColor: productLabels.map((_, index) => palette[index % palette.length]),
+                    borderColor: '#ffffff',
+                    borderWidth: 2
+                }]
+            }, {
+                plugins: {
+                    legend: {
+                        position: 'bottom',
+                        labels: { boxWidth: 18, padding: 15 }
+                    }
+                }
+            });
+
+            const monthlyAggregation = aggregateMonthly(filteredData);
+            renderChart('monthlyChart', 'line', {
+                labels: monthlyAggregation.labels,
+                datasets: [{
+                    label: 'Ventas',
+                    data: monthlyAggregation.sales,
+                    borderColor: '#667eea',
+                    backgroundColor: 'rgba(102, 126, 234, 0.2)',
+                    fill: true,
+                    tension: 0.35,
+                    pointRadius: 4,
+                    pointBackgroundColor: '#667eea'
+                }, {
+                    label: 'Utilidad',
+                    data: monthlyAggregation.profit,
+                    borderColor: '#43cea2',
+                    backgroundColor: 'rgba(67, 206, 162, 0.2)',
+                    fill: true,
+                    tension: 0.35,
+                    pointRadius: 4,
+                    pointBackgroundColor: '#43cea2'
+                }]
+            }, {
+                scales: {
+                    y: { beginAtZero: true, ticks: { callback: value => formatCurrency(value) } }
+                }
+            });
+
+            const discountAggregation = aggregateByKey(filteredData, 'discountBand');
+            const discountLabels = Object.keys(discountAggregation);
+            const discountSales = discountLabels.map(label => discountAggregation[label].sales);
+            const discountValue = discountLabels.map(label => discountAggregation[label].discounts);
+            renderChart('discountChart', 'bar', {
+                labels: discountLabels,
+                datasets: [
+                    {
+                        label: 'Ventas',
+                        data: discountSales,
+                        backgroundColor: 'rgba(102, 126, 234, 0.7)',
+                        borderColor: '#667eea',
+                        borderWidth: 1
+                    },
+                    {
+                        label: 'Descuentos',
+                        data: discountValue,
+                        backgroundColor: 'rgba(240, 147, 251, 0.7)',
+                        borderColor: '#f093fb',
+                        borderWidth: 1
+                    }
+                ]
+            }, {
+                scales: {
+                    y: { beginAtZero: true, ticks: { callback: value => formatCurrency(value) } }
+                }
+            });
+
+            const profitability = segmentLabels.map(label => {
+                const data = segmentAggregation[label];
+                const margin = data.sales > 0 ? (data.profit / data.sales) * 100 : 0;
+                return Number(margin.toFixed(1));
+            });
+            renderChart('profitabilityChart', 'bar', {
+                labels: segmentLabels,
+                datasets: [{
+                    label: 'Margen %',
+                    data: profitability,
+                    backgroundColor: segmentLabels.map((_, index) => palette[(index + 2) % palette.length]),
+                    borderRadius: 12
+                }]
+            }, {
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        max: Math.min(100, Math.ceil(Math.max(...profitability, 10) / 10) * 10),
+                        ticks: { callback: value => value + '%' }
+                    }
+                }
+            });
+        }
+
+        function renderChart(elementId, type, data, options = {}) {
+            const ctx = document.getElementById(elementId).getContext('2d');
+            if (charts[elementId]) {
+                charts[elementId].data = data;
+                charts[elementId].options = { ...charts[elementId].options, ...options };
+                charts[elementId].update();
+            } else {
+                charts[elementId] = new Chart(ctx, { type, data, options });
+            }
+        }
+
+        function aggregateByKey(data, key) {
+            return data.reduce((acc, row) => {
+                const label = row[key] || 'No definido';
+                if (!acc[label]) {
+                    acc[label] = { sales: 0, profit: 0, discounts: 0, units: 0 };
+                }
+                acc[label].sales += row.sales || 0;
+                acc[label].profit += row.profit || 0;
+                acc[label].discounts += row.discounts || 0;
+                acc[label].units += row.unitsSold || 0;
+                return acc;
+            }, {});
+        }
+
+        function aggregateMonthly(data) {
+            const monthMap = {};
+            data.forEach(row => {
+                const key = `${row.year}-${String(row.monthNumber).padStart(2, '0')}`;
+                if (!monthMap[key]) {
+                    monthMap[key] = {
+                        label: `${row.monthName} ${row.year}`,
+                        sales: 0,
+                        profit: 0
+                    };
+                }
+                monthMap[key].sales += row.sales || 0;
+                monthMap[key].profit += row.profit || 0;
+            });
+
+            const sortedKeys = Object.keys(monthMap).sort();
+            return {
+                labels: sortedKeys.map(key => monthMap[key].label),
+                sales: sortedKeys.map(key => monthMap[key].sales),
+                profit: sortedKeys.map(key => monthMap[key].profit)
+            };
+        }
+
+        function generateInsights() {
+            const container = document.getElementById('insightsContainer');
+            container.innerHTML = '';
+
+            if (filteredData.length === 0) {
+                container.innerHTML = '<div class="loading">No hay registros que coincidan con los filtros seleccionados.</div>';
+                return;
+            }
+
+            const totalSales = filteredData.reduce((sum, row) => sum + (row.sales || 0), 0);
+            const totalProfit = filteredData.reduce((sum, row) => sum + (row.profit || 0), 0);
+            const segmentAggregation = aggregateByKey(filteredData, 'segment');
+            const countryAggregation = aggregateByKey(filteredData, 'country');
+            const productAggregation = aggregateByKey(filteredData, 'product');
+
+            const topSegment = Object.entries(segmentAggregation).sort((a, b) => b[1].sales - a[1].sales)[0];
+            const topCountry = Object.entries(countryAggregation).sort((a, b) => b[1].profit - a[1].profit)[0];
+            const topMarginProduct = Object.entries(productAggregation).map(([product, values]) => ({
+                product,
+                margin: values.sales > 0 ? (values.profit / values.sales) * 100 : 0,
+                profit: values.profit
+            })).sort((a, b) => b.margin - a.margin)[0];
+
+            const insights = [
+                `El segmento <strong>${topSegment[0]}</strong> concentra el ${(topSegment[1].sales / totalSales * 100).toFixed(1)}% de las ventas filtradas, con ${formatCurrency(topSegment[1].sales)} generados.`,
+                `El país con mayor utilidad es <strong>${topCountry[0]}</strong>, aportando ${formatCurrency(topCountry[1].profit)} y un margen del ${(topCountry[1].profit / topCountry[1].sales * 100).toFixed(1)}%.`,
+                `El producto con la mejor rentabilidad es <strong>${topMarginProduct.product}</strong>, alcanzando un margen del ${topMarginProduct.margin.toFixed(1)}% y utilidades por ${formatCurrency(topMarginProduct.profit)}.`
+            ];
+
+            insights.forEach(text => {
+                const item = document.createElement('div');
+                item.className = 'insight-item';
+                item.innerHTML = text;
+                container.appendChild(item);
+            });
+        }
+
+        function exportData() {
+            if (!filteredData.length) {
+                alert('No hay datos para exportar con los filtros actuales.');
+                return;
+            }
+
+            const headers = ['Segmento', 'País', 'Producto', 'Banda de Descuento', 'Unidades Vendidas', 'Precio de Fabricación', 'Precio de Venta', 'Ventas Brutas', 'Descuentos', 'Ventas Netas', 'COGS', 'Utilidad', 'Fecha', 'Mes', 'Año'];
+            const rows = filteredData.map(row => [
+                row.segment,
+                row.country,
+                row.product,
+                row.discountBand,
+                row.unitsSold,
+                row.manufacturingPrice,
+                row.salePrice,
+                row.grossSales,
+                row.discounts,
+                row.sales,
+                row.cogs,
+                row.profit,
+                row.date,
+                row.monthName,
+                row.year
+            ]);
+
+            const csvContent = [headers, ...rows]
+                .map(line => line.map(value => typeof value === 'string' && value.includes(',') ? `"${value}"` : value).join(','))
+                .join('\n');
+
+            const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+            const link = document.createElement('a');
+            const url = URL.createObjectURL(blob);
+            link.setAttribute('href', url);
+            link.setAttribute('download', `dashboard-financiero-${Date.now()}.csv`);
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
+        }
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
         <ul class="navbar-nav ml-auto align-items-lg-center">
           <li class="nav-item"><a class="nav-link" href="index.html">Inicio</a></li>
           <li class="nav-item"><a class="nav-link" href="shop.html">Tienda</a></li>
+          <li class="nav-item"><a class="nav-link" href="dashboard-financiero.html">Reportes</a></li>
           <li class="nav-item"><a class="nav-link" href="contact.html">Contacto</a></li>
 
           <!-- Admin / Panel -->


### PR DESCRIPTION
## Summary
- add a standalone executive sales dashboard page with interactive filters, KPIs, and visualizations powered by Chart.js
- preload curated sales dataset, dynamic insights, and CSV export utilities for decision support
- link the main navigation to the new dashboard for quick access

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d8b00f6e7c832592e6ed6397deda6f