### PR TITLE
Add Supabase admin configuration panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Js/config.js

--- a/Js/config.sample.js
+++ b/Js/config.sample.js
@@ -1,0 +1,8 @@
+// Copia este archivo como "Js/config.js" y reemplaza los valores por las credenciales
+// de tu proyecto en https://app.supabase.com. Nunca compartas la service_role key en
+// el frontend, únicamente la anon key pública.
+
+window.APP_CONFIG = {
+  supabaseUrl: 'https://iqpgmxoeovuhpfbqjqme.supabase.co',
+  supabaseAnonKey: 'REEMPLAZA_CON_TU_SUPABASE_ANON_KEY'
+};

--- a/Js/settings.js
+++ b/Js/settings.js
@@ -1,0 +1,783 @@
+/**
+ * Panel de configuración conectado a Supabase.
+ * Tablas esperadas:
+ *  - usuario: usuario_id (PK), nombre, email, telefono, rol_id (FK rol.rol_id), estado, password_hash, ultimo_acceso.
+ *  - rol: rol_id (PK), nombre, descripcion, nivel.
+ *  - permiso: permiso_id (PK), codigo, categoria, descripcion.
+ *  - rol_permiso: (PK opcional), rol_id, permiso_id.
+ *  - auditoria: auditoria_id (PK), entidad, accion, detalle, usuario/usuario_id/usuario_email, fecha/timestamp.
+ */
+const settingsWrapper = document.getElementById('settingsWrapper');
+const settingsStatus = document.getElementById('settingsStatus');
+const settingsPlaceholder = document.getElementById('settingsPlaceholder');
+
+const state = {
+  users: [],
+  roles: [],
+  permissions: [],
+  rolePermissions: [],
+  auditRaw: [],
+  audit: [],
+  auditFilters: {
+    entidad: '',
+    usuario: ''
+  }
+};
+
+let client = null;
+
+function showStatus(message, type = 'info', timeout = 4500) {
+  if (!settingsStatus) return;
+  settingsStatus.textContent = message;
+  settingsStatus.classList.toggle('error', type === 'error');
+  settingsStatus.style.display = 'block';
+
+  window.clearTimeout(showStatus._timeoutId);
+  if (timeout && timeout > 0) {
+    showStatus._timeoutId = window.setTimeout(() => {
+      settingsStatus.style.display = 'none';
+    }, timeout);
+  }
+}
+
+function hideStatus() {
+  if (!settingsStatus) return;
+  window.clearTimeout(showStatus._timeoutId);
+  settingsStatus.style.display = 'none';
+}
+
+function setPlaceholderVisible(visible) {
+  if (!settingsPlaceholder) return;
+  if (visible) {
+    settingsPlaceholder.hidden = false;
+    settingsPlaceholder.style.display = '';
+  } else {
+    settingsPlaceholder.hidden = true;
+    settingsPlaceholder.style.display = 'none';
+  }
+}
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function nullableValue(value) {
+  const cleaned = normalizeString(value);
+  return cleaned ? cleaned : null;
+}
+
+function firstAvailable(obj, candidates, fallback = undefined) {
+  if (!obj) return fallback;
+  for (const key of candidates) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const value = obj[key];
+      if (value !== null && value !== undefined) {
+        return value;
+      }
+    }
+  }
+  return fallback;
+}
+
+function formatDateTime(value) {
+  if (!value) return '';
+  let date = value;
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) {
+      date = new Date(parsed);
+    }
+  }
+  if (typeof date === 'number') {
+    date = new Date(date);
+  }
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+  return new Intl.DateTimeFormat('es-GT', {
+    dateStyle: 'short',
+    timeStyle: 'short'
+  }).format(date);
+}
+
+async function hashPassword(plain) {
+  if (!plain) return null;
+  const encoder = new TextEncoder();
+  const data = encoder.encode(plain);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map(byte => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function renderUsers() {
+  const tbody = settingsWrapper?.querySelector('[data-users-body]');
+  if (!tbody) return;
+
+  if (!state.users.length) {
+    tbody.innerHTML = '<tr><td colspan="6" class="settings-empty">Sin usuarios registrados todavía.</td></tr>';
+    return;
+  }
+
+  const rows = state.users.map(user => {
+    const id = firstAvailable(user, ['usuario_id', 'id']);
+    const roleId = firstAvailable(user, ['rol_id', 'role_id']);
+    const roleName = state.roles.find(r => firstAvailable(r, ['rol_id', 'id']) === roleId)?.nombre ?? '—';
+    const status = normalizeString(firstAvailable(user, ['estado', 'status', 'activo'])) || 'activo';
+    const lastAccess = firstAvailable(user, ['ultimo_acceso', 'last_login_at', 'updated_at', 'fecha_acceso']);
+
+    return `
+      <tr data-id="${id ?? ''}">
+        <td>${user.nombre ?? user.name ?? '—'}</td>
+        <td>${user.email ?? '—'}</td>
+        <td>${roleName}</td>
+        <td class="text-capitalize">${status}</td>
+        <td>${lastAccess ? formatDateTime(lastAccess) : '—'}</td>
+        <td class="text-right">
+          <button class="btn btn-link btn-sm" data-action="edit" data-id="${id}">Editar</button>
+          <button class="btn btn-link btn-sm text-danger" data-action="delete" data-id="${id}">Eliminar</button>
+        </td>
+      </tr>
+    `;
+  });
+
+  tbody.innerHTML = rows.join('');
+}
+
+function renderRoles() {
+  const tbody = settingsWrapper?.querySelector('[data-roles-body]');
+  const userRoleSelect = document.getElementById('userRol');
+  const rpRolSelect = document.getElementById('rpRol');
+
+  if (tbody) {
+    if (!state.roles.length) {
+      tbody.innerHTML = '<tr><td colspan="4" class="settings-empty">Sin roles disponibles.</td></tr>';
+    } else {
+      tbody.innerHTML = state.roles
+        .map(role => {
+          const id = firstAvailable(role, ['rol_id', 'id']);
+          const nivel = firstAvailable(role, ['nivel', 'priority']);
+          const descripcion = firstAvailable(role, ['descripcion', 'description']);
+          return `
+            <tr data-id="${id ?? ''}">
+              <td>${role.nombre ?? role.name ?? '—'}</td>
+              <td>${nivel ?? '—'}</td>
+              <td>${descripcion ?? '—'}</td>
+              <td class="text-right">
+                <button class="btn btn-link btn-sm" data-action="edit" data-id="${id}">Editar</button>
+                <button class="btn btn-link btn-sm text-danger" data-action="delete" data-id="${id}">Eliminar</button>
+              </td>
+            </tr>
+          `;
+        })
+        .join('');
+    }
+  }
+
+  const buildOptions = (select) => {
+    if (!select) return;
+    const currentValue = select.value;
+    select.innerHTML = '<option value="">Selecciona rol</option>' +
+      state.roles
+        .map(role => {
+          const id = firstAvailable(role, ['rol_id', 'id']);
+          const name = role.nombre ?? role.name ?? `Rol ${id}`;
+          return `<option value="${id}">${name}</option>`;
+        })
+        .join('');
+    if (currentValue) {
+      select.value = currentValue;
+    }
+  };
+
+  buildOptions(userRoleSelect);
+  buildOptions(rpRolSelect);
+}
+
+function renderPermissions() {
+  const tbody = settingsWrapper?.querySelector('[data-permissions-body]');
+  const rpPermisoSelect = document.getElementById('rpPermiso');
+
+  if (tbody) {
+    if (!state.permissions.length) {
+      tbody.innerHTML = '<tr><td colspan="4" class="settings-empty">Aún no has definido permisos.</td></tr>';
+    } else {
+      tbody.innerHTML = state.permissions
+        .map(permission => {
+          const id = firstAvailable(permission, ['permiso_id', 'id']);
+          const codigo = firstAvailable(permission, ['codigo', 'code']);
+          const categoria = firstAvailable(permission, ['categoria', 'category']);
+          const descripcion = firstAvailable(permission, ['descripcion', 'description']);
+          return `
+            <tr data-id="${id ?? ''}">
+              <td>${codigo ?? '—'}</td>
+              <td>${categoria ?? '—'}</td>
+              <td>${descripcion ?? '—'}</td>
+              <td class="text-right">
+                <button class="btn btn-link btn-sm" data-action="edit" data-id="${id}">Editar</button>
+                <button class="btn btn-link btn-sm text-danger" data-action="delete" data-id="${id}">Eliminar</button>
+              </td>
+            </tr>
+          `;
+        })
+        .join('');
+    }
+  }
+
+  if (rpPermisoSelect) {
+    const currentValue = rpPermisoSelect.value;
+    rpPermisoSelect.innerHTML = '<option value="">Selecciona permiso</option>' +
+      state.permissions
+        .map(permission => {
+          const id = firstAvailable(permission, ['permiso_id', 'id']);
+          const code = firstAvailable(permission, ['codigo', 'code', 'nombre']) ?? `Permiso ${id}`;
+          return `<option value="${id}">${code}</option>`;
+        })
+        .join('');
+    if (currentValue) {
+      rpPermisoSelect.value = currentValue;
+    }
+  }
+}
+
+function renderRolePermissions() {
+  const container = document.getElementById('rolePermissionList');
+  if (!container) return;
+
+  if (!state.rolePermissions.length) {
+    container.innerHTML = '<p class="settings-empty mb-0">Aún no hay permisos asociados a roles.</p>';
+    return;
+  }
+
+  const grouped = new Map();
+  for (const link of state.rolePermissions) {
+    const roleId = firstAvailable(link, ['rol_id', 'role_id']);
+    const permId = firstAvailable(link, ['permiso_id', 'permission_id']);
+    if (!roleId || !permId) continue;
+
+    const role = state.roles.find(r => firstAvailable(r, ['rol_id', 'id']) === roleId);
+    const permission = state.permissions.find(p => firstAvailable(p, ['permiso_id', 'id']) === permId);
+    const roleName = role?.nombre ?? role?.name ?? `Rol ${roleId}`;
+    const permName = firstAvailable(permission, ['codigo', 'code', 'nombre', 'name']) ?? `Permiso ${permId}`;
+
+    if (!grouped.has(roleId)) {
+      grouped.set(roleId, {
+        name: roleName,
+        permissions: []
+      });
+    }
+
+    grouped.get(roleId).permissions.push({
+      id: permId,
+      name: permName
+    });
+  }
+
+  const sections = Array.from(grouped.entries()).map(([roleId, info]) => {
+    const chips = info.permissions
+      .map(perm => `
+        <span class="settings-chip" data-role="${roleId}" data-permission="${perm.id}">
+          ${perm.name}
+          <button type="button" title="Quitar" data-action="remove-rp" data-role="${roleId}" data-permission="${perm.id}">×</button>
+        </span>
+      `)
+      .join('');
+
+    return `
+      <div class="mb-2" data-role="${roleId}">
+        <strong>${info.name}</strong>
+        <div class="mt-1">${chips || '<span class="text-muted">Sin permisos asignados.</span>'}</div>
+      </div>
+    `;
+  });
+
+  container.innerHTML = sections.join('');
+}
+
+function renderAudit() {
+  const tbody = settingsWrapper?.querySelector('[data-audit-body]');
+  if (!tbody) return;
+
+  if (!state.audit.length) {
+    tbody.innerHTML = '<tr><td colspan="5" class="settings-empty">No hay registros de auditoría para los filtros actuales.</td></tr>';
+    return;
+  }
+
+  tbody.innerHTML = state.audit
+    .map(entry => {
+      const fecha = firstAvailable(entry, ['fecha', 'created_at', 'fecha_evento', 'timestamp']);
+      const entidad = firstAvailable(entry, ['entidad', 'tabla', 'entity']);
+      const accion = firstAvailable(entry, ['accion', 'accion_realizada', 'action']);
+      const detalle = firstAvailable(entry, ['detalle', 'descripcion', 'description']);
+      const usuario = firstAvailable(entry, ['usuario', 'usuario_id', 'user_email', 'usuario_email']);
+
+      return `
+        <tr>
+          <td>${fecha ? formatDateTime(fecha) : '—'}</td>
+          <td>${entidad ?? '—'}</td>
+          <td>${accion ?? '—'}</td>
+          <td>${detalle ?? '—'}</td>
+          <td>${usuario ?? '—'}</td>
+        </tr>
+      `;
+    })
+    .join('');
+}
+
+function applyAuditFilters(data) {
+  const entidadFilter = normalizeString(state.auditFilters.entidad).toLowerCase();
+  const usuarioFilter = normalizeString(state.auditFilters.usuario).toLowerCase();
+
+  if (!entidadFilter && !usuarioFilter) return data;
+
+  return data.filter(entry => {
+    const entidad = normalizeString(firstAvailable(entry, ['entidad', 'tabla', 'entity'])).toLowerCase();
+    const usuario = normalizeString(firstAvailable(entry, ['usuario', 'usuario_id', 'user_email', 'usuario_email'])).toLowerCase();
+
+    const matchesEntidad = entidadFilter ? entidad.includes(entidadFilter) : true;
+    const matchesUsuario = usuarioFilter ? usuario.includes(usuarioFilter) : true;
+
+    return matchesEntidad && matchesUsuario;
+  });
+}
+
+function sortAudit(data) {
+  return [...data].sort((a, b) => {
+    const dateA = Date.parse(firstAvailable(a, ['fecha', 'created_at', 'fecha_evento', 'timestamp'])) || 0;
+    const dateB = Date.parse(firstAvailable(b, ['fecha', 'created_at', 'fecha_evento', 'timestamp'])) || 0;
+    return dateB - dateA;
+  });
+}
+
+function attachTableActions() {
+  const usersTbody = settingsWrapper?.querySelector('[data-users-body]');
+  const rolesTbody = settingsWrapper?.querySelector('[data-roles-body]');
+  const permissionsTbody = settingsWrapper?.querySelector('[data-permissions-body]');
+  const rpContainer = document.getElementById('rolePermissionList');
+
+  usersTbody?.addEventListener('click', async (event) => {
+    const button = event.target.closest('button[data-action]');
+    if (!button || !client) return;
+    const id = Number(button.dataset.id);
+    if (!id) return;
+
+    if (button.dataset.action === 'edit') {
+      const user = state.users.find(item => Number(firstAvailable(item, ['usuario_id', 'id'])) === id);
+      if (!user) return;
+      const form = document.getElementById('userForm');
+      if (!form) return;
+      form.usuario_id.value = id;
+      form.nombre.value = user.nombre ?? user.name ?? '';
+      form.email.value = user.email ?? '';
+      form.telefono.value = firstAvailable(user, ['telefono', 'phone']) ?? '';
+      form.rol_id.value = firstAvailable(user, ['rol_id', 'role_id']) ?? '';
+      form.estado.value = normalizeString(firstAvailable(user, ['estado', 'status', 'activo'])) || 'activo';
+      form.password.value = '';
+      showStatus('Editando usuario seleccionado. Guarda para aplicar cambios.', 'info', 3200);
+    } else if (button.dataset.action === 'delete') {
+      if (!window.confirm('¿Eliminar este usuario? Esta acción no se puede deshacer.')) return;
+      try {
+        const { error } = await client.from('usuario').delete().eq('usuario_id', id);
+        if (error) throw error;
+        showStatus('Usuario eliminado correctamente.');
+        await loadUsers();
+      } catch (error) {
+        console.error('[settings] Error al eliminar usuario', error);
+        showStatus(`No se pudo eliminar el usuario: ${error.message}`, 'error', 6500);
+      }
+    }
+  });
+
+  rolesTbody?.addEventListener('click', async (event) => {
+    const button = event.target.closest('button[data-action]');
+    if (!button || !client) return;
+    const id = Number(button.dataset.id);
+    if (!id) return;
+
+    if (button.dataset.action === 'edit') {
+      const role = state.roles.find(item => Number(firstAvailable(item, ['rol_id', 'id'])) === id);
+      if (!role) return;
+      const form = document.getElementById('roleForm');
+      if (!form) return;
+      form.rol_id.value = id;
+      form.nombre.value = role.nombre ?? role.name ?? '';
+      form.nivel.value = firstAvailable(role, ['nivel', 'priority']) ?? '';
+      form.descripcion.value = firstAvailable(role, ['descripcion', 'description']) ?? '';
+      showStatus('Editando rol seleccionado.', 'info', 3200);
+    } else if (button.dataset.action === 'delete') {
+      if (!window.confirm('¿Eliminar este rol? También se eliminarán sus asignaciones.')) return;
+      try {
+        const { error: relError } = await client.from('rol_permiso').delete().eq('rol_id', id);
+        if (relError) throw relError;
+        const usersWithRole = state.users.some(user => Number(firstAvailable(user, ['rol_id', 'role_id'])) === id);
+        if (usersWithRole) {
+          const { error: usersError } = await client.from('usuario').update({ rol_id: null }).eq('rol_id', id);
+          if (usersError) {
+            console.warn('[settings] No se pudo limpiar rol en usuarios', usersError);
+          }
+        }
+        const { error } = await client.from('rol').delete().eq('rol_id', id);
+        if (error) throw error;
+        showStatus('Rol eliminado correctamente.');
+        await Promise.all([loadRoles(), loadRolePermissions(), loadUsers()]);
+      } catch (error) {
+        console.error('[settings] Error al eliminar rol', error);
+        showStatus(`No se pudo eliminar el rol: ${error.message}`, 'error', 6500);
+      }
+    }
+  });
+
+  permissionsTbody?.addEventListener('click', async (event) => {
+    const button = event.target.closest('button[data-action]');
+    if (!button || !client) return;
+    const id = Number(button.dataset.id);
+    if (!id) return;
+
+    if (button.dataset.action === 'edit') {
+      const permission = state.permissions.find(item => Number(firstAvailable(item, ['permiso_id', 'id'])) === id);
+      if (!permission) return;
+      const form = document.getElementById('permissionForm');
+      if (!form) return;
+      form.permiso_id.value = id;
+      form.codigo.value = firstAvailable(permission, ['codigo', 'code', 'nombre']) ?? '';
+      form.categoria.value = firstAvailable(permission, ['categoria', 'category']) ?? '';
+      form.descripcion.value = firstAvailable(permission, ['descripcion', 'description']) ?? '';
+      showStatus('Editando permiso seleccionado.', 'info', 3200);
+    } else if (button.dataset.action === 'delete') {
+      if (!window.confirm('¿Eliminar este permiso? Se quitará de todos los roles.')) return;
+      try {
+        const { error: relError } = await client.from('rol_permiso').delete().eq('permiso_id', id);
+        if (relError) throw relError;
+        const { error } = await client.from('permiso').delete().eq('permiso_id', id);
+        if (error) throw error;
+        showStatus('Permiso eliminado correctamente.');
+        await Promise.all([loadPermissions(), loadRolePermissions()]);
+      } catch (error) {
+        console.error('[settings] Error al eliminar permiso', error);
+        showStatus(`No se pudo eliminar el permiso: ${error.message}`, 'error', 6500);
+      }
+    }
+  });
+
+  rpContainer?.addEventListener('click', async (event) => {
+    const button = event.target.closest('button[data-action="remove-rp"]');
+    if (!button || !client) return;
+    const rolId = Number(button.dataset.role);
+    const permisoId = Number(button.dataset.permission);
+    if (!rolId || !permisoId) return;
+
+    try {
+      const { error } = await client.from('rol_permiso').delete().match({ rol_id: rolId, permiso_id: permisoId });
+      if (error) throw error;
+      showStatus('Permiso retirado del rol.');
+      await loadRolePermissions();
+    } catch (error) {
+      console.error('[settings] Error al quitar permiso del rol', error);
+      showStatus(`No se pudo quitar el permiso: ${error.message}`, 'error', 6500);
+    }
+  });
+}
+
+async function loadUsers() {
+  if (!client) return;
+  try {
+    const { data, error } = await client.from('usuario').select('*');
+    if (error) throw error;
+    state.users = Array.isArray(data) ? data : [];
+    renderUsers();
+  } catch (error) {
+    console.error('[settings] Error al cargar usuarios', error);
+    showStatus(`Error al cargar usuarios: ${error.message}`, 'error', 6500);
+  }
+}
+
+async function loadRoles() {
+  if (!client) return;
+  try {
+    const { data, error } = await client.from('rol').select('*');
+    if (error) throw error;
+    state.roles = Array.isArray(data) ? data : [];
+    renderRoles();
+  } catch (error) {
+    console.error('[settings] Error al cargar roles', error);
+    showStatus(`Error al cargar roles: ${error.message}`, 'error', 6500);
+  }
+}
+
+async function loadPermissions() {
+  if (!client) return;
+  try {
+    const { data, error } = await client.from('permiso').select('*');
+    if (error) throw error;
+    state.permissions = Array.isArray(data) ? data : [];
+    renderPermissions();
+  } catch (error) {
+    console.error('[settings] Error al cargar permisos', error);
+    showStatus(`Error al cargar permisos: ${error.message}`, 'error', 6500);
+  }
+}
+
+async function loadRolePermissions() {
+  if (!client) return;
+  try {
+    const { data, error } = await client.from('rol_permiso').select('*');
+    if (error) throw error;
+    state.rolePermissions = Array.isArray(data) ? data : [];
+    renderRolePermissions();
+  } catch (error) {
+    console.error('[settings] Error al cargar asignaciones', error);
+    showStatus(`Error al cargar asignaciones: ${error.message}`, 'error', 6500);
+  }
+}
+
+async function loadAudit() {
+  if (!client) return;
+  try {
+    const { data, error } = await client.from('auditoria').select('*').limit(200);
+    if (error) throw error;
+    const sorted = sortAudit(Array.isArray(data) ? data : []);
+    state.auditRaw = sorted;
+    state.audit = applyAuditFilters(sorted);
+    renderAudit();
+  } catch (error) {
+    console.error('[settings] Error al cargar auditoría', error);
+    showStatus(`Error al cargar auditoría: ${error.message}`, 'error', 6500);
+  }
+}
+
+async function saveUser(event) {
+  event.preventDefault();
+  if (!client) return;
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const id = Number(formData.get('usuario_id')) || null;
+
+  const payload = {
+    nombre: nullableValue(formData.get('nombre')),
+    email: nullableValue(formData.get('email')),
+    telefono: nullableValue(formData.get('telefono')),
+    rol_id: Number(formData.get('rol_id')) || null,
+    estado: nullableValue(formData.get('estado')) || 'activo'
+  };
+
+  if (!payload.nombre || !payload.email) {
+    showStatus('Completa nombre y correo electrónico.', 'error', 5000);
+    return;
+  }
+
+  payload.email = payload.email.toLowerCase();
+
+  const password = normalizeString(formData.get('password'));
+  if (!id && !password) {
+    showStatus('Ingresa una contraseña temporal para nuevos usuarios.', 'error', 5000);
+    return;
+  }
+
+  if (password) {
+    payload.password_hash = await hashPassword(password);
+  }
+
+  try {
+    if (id) {
+      const { error } = await client.from('usuario').update(payload).eq('usuario_id', id);
+      if (error) throw error;
+      showStatus('Usuario actualizado correctamente.');
+    } else {
+      const { error } = await client.from('usuario').insert(payload);
+      if (error) throw error;
+      showStatus('Usuario creado correctamente.');
+    }
+    resetForm(form);
+    await loadUsers();
+  } catch (error) {
+    console.error('[settings] Error al guardar usuario', error);
+    showStatus(`No se pudo guardar el usuario: ${error.message}`, 'error', 6500);
+  }
+}
+
+async function saveRole(event) {
+  event.preventDefault();
+  if (!client) return;
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const id = Number(formData.get('rol_id')) || null;
+
+  const payload = {
+    nombre: nullableValue(formData.get('nombre')),
+    nivel: formData.get('nivel') ? Number(formData.get('nivel')) : null,
+    descripcion: nullableValue(formData.get('descripcion'))
+  };
+
+  if (!payload.nombre) {
+    showStatus('El nombre del rol es obligatorio.', 'error', 5000);
+    return;
+  }
+
+  try {
+    if (id) {
+      const { error } = await client.from('rol').update(payload).eq('rol_id', id);
+      if (error) throw error;
+      showStatus('Rol actualizado correctamente.');
+    } else {
+      const { error } = await client.from('rol').insert(payload);
+      if (error) throw error;
+      showStatus('Rol creado correctamente.');
+    }
+    resetForm(form);
+    await loadRoles();
+  } catch (error) {
+    console.error('[settings] Error al guardar rol', error);
+    showStatus(`No se pudo guardar el rol: ${error.message}`, 'error', 6500);
+  }
+}
+
+async function savePermission(event) {
+  event.preventDefault();
+  if (!client) return;
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const id = Number(formData.get('permiso_id')) || null;
+
+  const payload = {
+    codigo: nullableValue(formData.get('codigo')),
+    categoria: nullableValue(formData.get('categoria')),
+    descripcion: nullableValue(formData.get('descripcion'))
+  };
+
+  if (!payload.codigo) {
+    showStatus('El código del permiso es obligatorio.', 'error', 5000);
+    return;
+  }
+
+  try {
+    if (id) {
+      const { error } = await client.from('permiso').update(payload).eq('permiso_id', id);
+      if (error) throw error;
+      showStatus('Permiso actualizado correctamente.');
+    } else {
+      const { error } = await client.from('permiso').insert(payload);
+      if (error) throw error;
+      showStatus('Permiso creado correctamente.');
+    }
+    resetForm(form);
+    await loadPermissions();
+  } catch (error) {
+    console.error('[settings] Error al guardar permiso', error);
+    showStatus(`No se pudo guardar el permiso: ${error.message}`, 'error', 6500);
+  }
+}
+
+async function saveRolePermission(event) {
+  event.preventDefault();
+  if (!client) return;
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const rolId = Number(formData.get('rol_id'));
+  const permisoId = Number(formData.get('permiso_id'));
+  if (!rolId || !permisoId) {
+    showStatus('Selecciona un rol y un permiso para continuar.', 'error', 4000);
+    return;
+  }
+
+  const exists = state.rolePermissions.some(link => {
+    const rId = Number(firstAvailable(link, ['rol_id', 'role_id']));
+    const pId = Number(firstAvailable(link, ['permiso_id', 'permission_id']));
+    return rId === rolId && pId === permisoId;
+  });
+
+  if (exists) {
+    showStatus('Ese permiso ya está asignado al rol.', 'info', 3200);
+    return;
+  }
+
+  try {
+    const { error } = await client.from('rol_permiso').insert({ rol_id: rolId, permiso_id: permisoId });
+    if (error) throw error;
+    showStatus('Permiso asignado correctamente.');
+    resetForm(form);
+    await loadRolePermissions();
+  } catch (error) {
+    console.error('[settings] Error al asignar permiso', error);
+    showStatus(`No se pudo asignar el permiso: ${error.message}`, 'error', 6500);
+  }
+}
+
+function handleAuditFilter(event) {
+  event.preventDefault();
+  const form = event.currentTarget;
+  state.auditFilters.entidad = normalizeString(form.entidad?.value);
+  state.auditFilters.usuario = normalizeString(form.usuario?.value);
+  state.audit = applyAuditFilters(sortAudit(state.auditRaw));
+  renderAudit();
+}
+
+function resetForm(form) {
+  if (!form) return;
+  form.reset();
+  const hiddenInputs = form.querySelectorAll('input[type="hidden"]');
+  hiddenInputs.forEach(input => {
+    input.value = '';
+  });
+  if (form.id === 'userForm') {
+    const estadoField = form.querySelector('[name="estado"]');
+    if (estadoField) {
+      estadoField.value = 'activo';
+    }
+  }
+}
+
+async function initialize() {
+  if (!settingsWrapper) return;
+
+  const config = window.APP_CONFIG || {};
+  if (!window.supabase || !config.supabaseUrl || !config.supabaseAnonKey) {
+    setPlaceholderVisible(true);
+    showStatus('Configura tu URL y anon key de Supabase en Js/config.js para activar este módulo.', 'error', 0);
+    return;
+  }
+
+  client = window.supabase.createClient(config.supabaseUrl, config.supabaseAnonKey, {
+    auth: {
+      persistSession: false
+    }
+  });
+
+  setPlaceholderVisible(false);
+  settingsWrapper.hidden = false;
+
+  attachTableActions();
+
+  document.getElementById('userForm')?.addEventListener('submit', saveUser);
+  document.getElementById('roleForm')?.addEventListener('submit', saveRole);
+  document.getElementById('permissionForm')?.addEventListener('submit', savePermission);
+  document.getElementById('rolePermissionForm')?.addEventListener('submit', saveRolePermission);
+  document.getElementById('auditFilterForm')?.addEventListener('submit', handleAuditFilter);
+
+  document.getElementById('userReset')?.addEventListener('click', () => {
+    resetForm(document.getElementById('userForm'));
+    hideStatus();
+  });
+  document.getElementById('roleReset')?.addEventListener('click', () => {
+    resetForm(document.getElementById('roleForm'));
+    hideStatus();
+  });
+  document.getElementById('permissionReset')?.addEventListener('click', () => {
+    resetForm(document.getElementById('permissionForm'));
+    hideStatus();
+  });
+  document.getElementById('auditReset')?.addEventListener('click', async () => {
+    resetForm(document.getElementById('auditFilterForm'));
+    state.auditFilters = { entidad: '', usuario: '' };
+    await loadAudit();
+  });
+
+  await Promise.all([loadRoles(), loadPermissions()]);
+  await Promise.all([loadUsers(), loadRolePermissions(), loadAudit()]);
+  showStatus('Panel de configuración conectado correctamente.', 'info', 3200);
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initialize);
+} else {
+  initialize();
+}

--- a/admin.html
+++ b/admin.html
@@ -303,6 +303,129 @@
       margin: 0;
     }
 
+    .settings-wrapper {
+      margin-top: 24px;
+    }
+
+    .settings-status {
+      border-radius: 14px;
+      padding: 14px 18px;
+      margin-bottom: 16px;
+      background: rgba(42, 82, 152, 0.12);
+      color: #1e3c72;
+      font-weight: 500;
+      display: none;
+    }
+
+    .settings-status.error {
+      background: rgba(220, 53, 69, 0.12);
+      color: #b02a37;
+    }
+
+    .settings-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: 22px;
+    }
+
+    .settings-panel {
+      background: rgba(255, 255, 255, 0.9);
+      border-radius: 20px;
+      padding: 22px 20px;
+      box-shadow: 0 16px 36px rgba(30, 60, 114, 0.18);
+      display: flex;
+      flex-direction: column;
+      min-height: 100%;
+    }
+
+    .settings-panel h3 {
+      font-size: 1.15rem;
+      font-weight: 600;
+      margin-bottom: 12px;
+      color: #1f2a40;
+    }
+
+    .settings-panel .panel-description {
+      font-size: 0.9rem;
+      color: #5c6c8c;
+      margin-bottom: 18px;
+    }
+
+    .settings-panel form {
+      background: rgba(242, 247, 255, 0.7);
+      border-radius: 16px;
+      padding: 14px 16px;
+      margin-bottom: 18px;
+    }
+
+    .settings-panel form .form-group:last-child {
+      margin-bottom: 0;
+    }
+
+    .settings-panel table {
+      width: 100%;
+      font-size: 0.87rem;
+      margin-bottom: 0;
+    }
+
+    .settings-panel table thead th {
+      border-top: none;
+      background: rgba(30, 60, 114, 0.05);
+    }
+
+    .settings-panel table tbody td {
+      vertical-align: middle;
+    }
+
+    .settings-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 10px;
+      border-radius: 999px;
+      background: rgba(30, 60, 114, 0.12);
+      color: #1e3c72;
+      font-size: 0.75rem;
+      margin: 4px 6px 4px 0;
+    }
+
+    .settings-chip button {
+      border: none;
+      background: transparent;
+      color: inherit;
+      padding: 0;
+      line-height: 1;
+      cursor: pointer;
+    }
+
+    .settings-inline {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 12px;
+    }
+
+    .settings-empty {
+      font-size: 0.9rem;
+      color: #6c7a92;
+      text-align: center;
+      padding: 18px 0;
+    }
+
+    .settings-subsection {
+      margin-bottom: 20px;
+    }
+
+    .settings-subsection:last-child {
+      margin-bottom: 0;
+    }
+
+    .settings-subsection h4 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-bottom: 10px;
+      color: #1e3c72;
+    }
+
     /* Dropzone adjustments */
     .drop-zone {
       border: 2px dashed rgba(30, 60, 114, 0.35);
@@ -512,19 +635,248 @@
 
         <section class="content-section" id="section-settings">
           <div class="section-card">
-            <h2 class="section-title">Configuración y seguridad</h2>
-            <div class="placeholder-panel">
-              <div class="placeholder-card">
-                <h4>Usuarios y roles</h4>
-                <p>Define accesos por perfil para proteger información sensible y delegar funciones operativas.</p>
+            <div class="d-flex flex-wrap align-items-center justify-content-between mb-3">
+              <div>
+                <h2 class="section-title mb-1">Configuración y seguridad</h2>
+                <p class="text-muted mb-0">Administra usuarios, roles, permisos y auditorías vinculados a tu instancia de Supabase.</p>
               </div>
-              <div class="placeholder-card">
-                <h4>Preferencias del panel</h4>
-                <p>Personaliza colores, notificaciones y accesos directos a los módulos más utilizados por tu equipo.</p>
-              </div>
-              <div class="placeholder-card">
-                <h4>Auditoría</h4>
-                <p>Monitorea cambios realizados en el sistema y mantén un historial completo de modificaciones.</p>
+              <span class="badge badge-pill badge-info">Supabase</span>
+            </div>
+
+            <div id="settingsStatus" class="settings-status" role="status"></div>
+            <div id="settingsPlaceholder" class="settings-empty">Copia <code>Js/config.sample.js</code> a <code>Js/config.js</code> y coloca tu <strong>SUPABASE_URL</strong> y <strong>anon key</strong> para activar este panel.</div>
+
+            <div class="settings-wrapper" id="settingsWrapper" hidden>
+              <div class="settings-grid">
+                <article class="settings-panel" id="settingsUsers">
+                  <h3>Usuarios y roles</h3>
+                  <p class="panel-description">Gestiona cuentas internas y asigna roles según las responsabilidades dentro del negocio.</p>
+
+                  <form id="userForm" autocomplete="off">
+                    <input type="hidden" name="usuario_id" />
+                    <div class="form-row">
+                      <div class="form-group col-md-6">
+                        <label for="userNombre">Nombre</label>
+                        <input id="userNombre" name="nombre" type="text" class="form-control" required />
+                      </div>
+                      <div class="form-group col-md-6">
+                        <label for="userEmail">Correo electrónico</label>
+                        <input id="userEmail" name="email" type="email" class="form-control" required />
+                      </div>
+                    </div>
+
+                    <div class="form-row">
+                      <div class="form-group col-md-4">
+                        <label for="userTelefono">Teléfono</label>
+                        <input id="userTelefono" name="telefono" type="text" class="form-control" placeholder="+502..." />
+                      </div>
+                      <div class="form-group col-md-4">
+                        <label for="userRol">Rol</label>
+                        <select id="userRol" name="rol_id" class="form-control" required>
+                          <option value="">Selecciona rol</option>
+                        </select>
+                      </div>
+                      <div class="form-group col-md-4">
+                        <label for="userEstado">Estado</label>
+                        <select id="userEstado" name="estado" class="form-control">
+                          <option value="activo">Activo</option>
+                          <option value="inactivo">Inactivo</option>
+                          <option value="suspendido">Suspendido</option>
+                        </select>
+                      </div>
+                    </div>
+
+                    <div class="form-row">
+                      <div class="form-group col-md-6">
+                        <label for="userPassword">Contraseña temporal</label>
+                        <input id="userPassword" name="password" type="password" class="form-control" placeholder="Opcional" autocomplete="new-password" />
+                        <small class="form-text text-muted">Se almacenará como hash SHA-256. Úsala para restablecer accesos puntuales.</small>
+                      </div>
+                      <div class="form-group col-md-6 align-self-end text-right">
+                        <button class="btn btn-primary btn-sm" type="submit">Guardar usuario</button>
+                        <button class="btn btn-link btn-sm text-danger" id="userReset" type="button">Cancelar</button>
+                      </div>
+                    </div>
+                  </form>
+
+                  <div class="table-responsive">
+                    <table class="table table-hover table-sm" id="settingsUsersTable">
+                      <thead>
+                        <tr>
+                          <th>Nombre</th>
+                          <th>Correo</th>
+                          <th>Rol</th>
+                          <th>Estado</th>
+                          <th>Último acceso</th>
+                          <th class="text-right">Acciones</th>
+                        </tr>
+                      </thead>
+                      <tbody data-users-body>
+                        <tr>
+                          <td colspan="6" class="settings-empty">Conecta Supabase para ver tus usuarios administrativos.</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </article>
+
+                <article class="settings-panel" id="settingsRoles">
+                  <h3>Roles y permisos</h3>
+                  <p class="panel-description">Crea roles personalizados, mantén tu catálogo de permisos y controla qué puede hacer cada perfil.</p>
+
+                  <div class="settings-subsection">
+                    <h4>Roles</h4>
+                    <form id="roleForm" autocomplete="off">
+                      <input type="hidden" name="rol_id" />
+                      <div class="form-row">
+                        <div class="form-group col-md-6">
+                          <label for="roleNombre">Nombre</label>
+                          <input id="roleNombre" name="nombre" type="text" class="form-control" required />
+                        </div>
+                        <div class="form-group col-md-6">
+                          <label for="roleNivel">Nivel</label>
+                          <input id="roleNivel" name="nivel" type="number" class="form-control" min="1" step="1" placeholder="1 = mayor prioridad" />
+                          <small class="form-text text-muted">El nivel ayuda a ordenar jerarquías. Valores bajos indican mayor privilegio.</small>
+                        </div>
+                      </div>
+                      <div class="form-group">
+                        <label for="roleDescripcion">Descripción</label>
+                        <textarea id="roleDescripcion" name="descripcion" class="form-control" rows="2" placeholder="Ej. Gestiona inventarios y catálogos."></textarea>
+                      </div>
+                      <div class="text-right">
+                        <button class="btn btn-primary btn-sm" type="submit">Guardar rol</button>
+                        <button class="btn btn-link btn-sm text-danger" id="roleReset" type="button">Cancelar</button>
+                      </div>
+                    </form>
+
+                    <div class="table-responsive">
+                      <table class="table table-sm table-hover" id="settingsRolesTable">
+                        <thead>
+                          <tr>
+                            <th>Rol</th>
+                            <th>Nivel</th>
+                            <th>Descripción</th>
+                            <th class="text-right">Acciones</th>
+                          </tr>
+                        </thead>
+                        <tbody data-roles-body>
+                          <tr>
+                            <td colspan="4" class="settings-empty">Sin roles cargados todavía.</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+
+                  <div class="settings-subsection">
+                    <h4>Permisos</h4>
+                    <form id="permissionForm" autocomplete="off">
+                      <input type="hidden" name="permiso_id" />
+                      <div class="form-row">
+                        <div class="form-group col-md-4">
+                          <label for="permisoCodigo">Código</label>
+                          <input id="permisoCodigo" name="codigo" type="text" class="form-control" placeholder="inventario.listar" required />
+                        </div>
+                        <div class="form-group col-md-4">
+                          <label for="permisoCategoria">Categoría</label>
+                          <input id="permisoCategoria" name="categoria" type="text" class="form-control" placeholder="Inventario" />
+                        </div>
+                        <div class="form-group col-md-4">
+                          <label for="permisoDescripcion">Descripción</label>
+                          <input id="permisoDescripcion" name="descripcion" type="text" class="form-control" placeholder="Acceso a listado de productos" />
+                        </div>
+                      </div>
+                      <div class="text-right">
+                        <button class="btn btn-primary btn-sm" type="submit">Guardar permiso</button>
+                        <button class="btn btn-link btn-sm text-danger" id="permissionReset" type="button">Cancelar</button>
+                      </div>
+                    </form>
+
+                    <div class="table-responsive">
+                      <table class="table table-sm table-hover" id="settingsPermissionsTable">
+                        <thead>
+                          <tr>
+                            <th>Código</th>
+                            <th>Categoría</th>
+                            <th>Descripción</th>
+                            <th class="text-right">Acciones</th>
+                          </tr>
+                        </thead>
+                        <tbody data-permissions-body>
+                          <tr>
+                            <td colspan="4" class="settings-empty">Registra tus primeros permisos para habilitar accesos avanzados.</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+
+                  <div class="settings-subsection">
+                    <h4>Asignación de permisos</h4>
+                    <form id="rolePermissionForm" class="settings-inline" autocomplete="off">
+                      <div class="form-group mb-0">
+                        <label for="rpRol">Rol</label>
+                        <select id="rpRol" name="rol_id" class="form-control" required>
+                          <option value="">Selecciona rol</option>
+                        </select>
+                      </div>
+                      <div class="form-group mb-0">
+                        <label for="rpPermiso">Permiso</label>
+                        <select id="rpPermiso" name="permiso_id" class="form-control" required>
+                          <option value="">Selecciona permiso</option>
+                        </select>
+                      </div>
+                      <div class="form-group mb-0 align-self-end text-right">
+                        <button class="btn btn-outline-primary btn-sm" type="submit">Asignar</button>
+                      </div>
+                    </form>
+
+                    <div id="rolePermissionList" class="mt-3">
+                      <p class="settings-empty mb-0">Aún no hay permisos asociados a roles.</p>
+                    </div>
+                  </div>
+                </article>
+
+                <article class="settings-panel" id="settingsAudit">
+                  <h3>Auditoría</h3>
+                  <p class="panel-description">Revisa el historial de acciones registradas en tu tabla <code>auditoria</code> para identificar cambios sensibles.</p>
+
+                  <div class="settings-subsection">
+                    <form id="auditFilterForm" class="settings-inline" autocomplete="off">
+                      <div class="form-group mb-0">
+                        <label for="auditEntidad">Entidad</label>
+                        <input id="auditEntidad" name="entidad" type="text" class="form-control" placeholder="Ej. usuario" />
+                      </div>
+                      <div class="form-group mb-0">
+                        <label for="auditUsuario">Usuario</label>
+                        <input id="auditUsuario" name="usuario" type="text" class="form-control" placeholder="ID o correo" />
+                      </div>
+                      <div class="form-group mb-0 align-self-end text-right">
+                        <button class="btn btn-outline-primary btn-sm" type="submit">Filtrar</button>
+                        <button class="btn btn-link btn-sm" id="auditReset" type="button">Limpiar</button>
+                      </div>
+                    </form>
+                  </div>
+
+                  <div class="table-responsive flex-grow-1">
+                    <table class="table table-sm table-striped mb-0" id="settingsAuditTable">
+                      <thead>
+                        <tr>
+                          <th>Fecha</th>
+                          <th>Entidad</th>
+                          <th>Acción</th>
+                          <th>Detalle</th>
+                          <th>Usuario</th>
+                        </tr>
+                      </thead>
+                      <tbody data-audit-body>
+                        <tr>
+                          <td colspan="5" class="settings-empty">Conecta Supabase para consultar los eventos de auditoría.</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </article>
               </div>
             </div>
           </div>
@@ -618,6 +970,9 @@
 
   <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="Js/config.js"></script>
+  <script type="module" src="Js/settings.js"></script>
   <script type="module" src="Js/admin.js"></script>
   <script>
     const layout = document.getElementById('adminLayout');


### PR DESCRIPTION
## Summary
- replace the configuration section of the admin dashboard with a Supabase-aware panel for managing usuarios, roles, permisos y auditoría
- add a dedicated settings controller that integrates with Supabase and documents the expected Joyeria tables
- provide a sample Supabase configuration file and ignore the real credentials in version control

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68dc978d7bc08325ab76c73c0b480ee3