### PR TITLE
Improve configuration module responsiveness

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -358,8 +358,40 @@
       margin-bottom: 18px;
     }
 
+    .settings-panel form .form-row {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 12px 16px;
+    }
+
+    .settings-panel form .form-group {
+      margin-bottom: 12px;
+      min-width: 0;
+    }
+
     .settings-panel form .form-group:last-child {
       margin-bottom: 0;
+    }
+
+    .settings-panel form .form-group.align-self-end,
+    .settings-inline .form-group.align-self-end {
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      align-items: flex-end;
+      gap: 8px;
+    }
+
+    .settings-panel form .form-group.text-right {
+      text-align: right;
+    }
+
+    .settings-panel .form-control,
+    .settings-panel textarea,
+    .settings-panel select {
+      width: 100%;
+      min-width: 0;
+      display: block;
     }
 
     .settings-panel table {
@@ -400,8 +432,48 @@
 
     .settings-inline {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 12px 16px;
+    }
+
+    .settings-inline .form-group {
+      margin-bottom: 0;
+      min-width: 0;
+    }
+
+    .settings-panel .table-responsive {
+      width: 100%;
+      overflow-x: auto;
+      border-radius: 14px;
+    }
+
+    .settings-panel .table-responsive::-webkit-scrollbar {
+      height: 6px;
+    }
+
+    .settings-panel .table-responsive::-webkit-scrollbar-thumb {
+      background: rgba(30, 60, 114, 0.25);
+      border-radius: 999px;
+    }
+
+    @media (max-width: 576px) {
+      .settings-panel form .form-row {
+        grid-template-columns: 1fr;
+      }
+
+      .settings-inline {
+        grid-template-columns: 1fr;
+      }
+
+      .settings-panel form .form-group.align-self-end,
+      .settings-inline .form-group.align-self-end {
+        align-items: stretch;
+      }
+
+      .settings-panel form .form-group.align-self-end .btn,
+      .settings-inline .form-group.align-self-end .btn {
+        width: 100%;
+      }
     }
 
     .settings-empty {


### PR DESCRIPTION
## Summary
- adjust the configuration panel grid to keep form fields responsive within their cards
- ensure controls and inline filters stretch correctly on small screens
- add responsive table wrappers to prevent horizontal overflow while preserving scroll support

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dde6d61a0c83258fcdca6eb8c62abe