### PR TITLE
Refine configuration panel input layout

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -354,12 +354,76 @@
     .settings-panel form {
       background: rgba(242, 247, 255, 0.7);
       border-radius: 16px;
-      padding: 14px 16px;
+      padding: 16px 18px;
       margin-bottom: 18px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
     }
 
-    .settings-panel form .form-group:last-child {
+    .settings-panel form .form-row {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 16px;
+    }
+
+    .settings-panel form .form-group {
+      margin: 0;
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .settings-panel form .form-group.form-actions {
+      flex-direction: row;
+      align-items: flex-end;
+      justify-content: flex-end;
+      gap: 10px;
+    }
+
+    .settings-panel form .form-group.form-actions .btn {
+      min-width: 140px;
+    }
+
+    .settings-panel form .form-group.form-actions .btn-link {
+      min-width: auto;
+      padding-left: 0;
+      padding-right: 0;
+    }
+
+    .settings-panel label {
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: #32446b;
       margin-bottom: 0;
+    }
+
+    .settings-panel small.form-text {
+      color: #6c7a92;
+      line-height: 1.35;
+    }
+
+    .settings-panel .form-control,
+    .settings-panel textarea,
+    .settings-panel select {
+      width: 100%;
+      min-width: 0;
+      border-radius: 12px;
+      border: 1px solid rgba(30, 60, 114, 0.2);
+      background-color: rgba(255, 255, 255, 0.95);
+      padding: 10px 12px;
+      font-size: 0.95rem;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+    }
+
+    .settings-panel .form-control:focus,
+    .settings-panel textarea:focus,
+    .settings-panel select:focus {
+      border-color: #2a5298;
+      box-shadow: 0 0 0 0.15rem rgba(42, 82, 152, 0.25);
+      background-color: #fff;
+      outline: none;
     }
 
     .settings-panel table {
@@ -400,8 +464,69 @@
 
     .settings-inline {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 16px;
+      align-items: end;
+    }
+
+    .settings-inline .form-group {
+      margin: 0;
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .settings-inline .form-group.form-actions {
+      flex-direction: row;
+      align-items: flex-end;
+      justify-content: flex-end;
+      gap: 10px;
+      justify-self: end;
+    }
+
+    .settings-panel .table-responsive {
+      width: 100%;
+      overflow-x: auto;
+      border-radius: 14px;
+    }
+
+    .settings-panel .table-responsive::-webkit-scrollbar {
+      height: 6px;
+    }
+
+    .settings-panel .table-responsive::-webkit-scrollbar-thumb {
+      background: rgba(30, 60, 114, 0.25);
+      border-radius: 999px;
+    }
+
+    @media (max-width: 576px) {
+      .settings-panel form {
+        padding: 14px;
+      }
+
+      .settings-panel form .form-row {
+        grid-template-columns: 1fr;
+      }
+
+      .settings-inline {
+        grid-template-columns: 1fr;
+      }
+
+      .settings-panel form .form-group.form-actions,
+      .settings-inline .form-group.form-actions {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .settings-panel form .form-group.form-actions .btn,
+      .settings-inline .form-group.form-actions .btn {
+        width: 100%;
+      }
+
+      .settings-inline .form-group.form-actions {
+        justify-self: stretch;
+      }
     }
 
     .settings-empty {
@@ -655,28 +780,28 @@
                   <form id="userForm" autocomplete="off">
                     <input type="hidden" name="usuario_id" />
                     <div class="form-row">
-                      <div class="form-group col-md-6">
+                      <div class="form-group">
                         <label for="userNombre">Nombre</label>
                         <input id="userNombre" name="nombre" type="text" class="form-control" required />
                       </div>
-                      <div class="form-group col-md-6">
+                      <div class="form-group">
                         <label for="userEmail">Correo electrónico</label>
                         <input id="userEmail" name="email" type="email" class="form-control" required />
                       </div>
                     </div>
 
                     <div class="form-row">
-                      <div class="form-group col-md-4">
+                      <div class="form-group">
                         <label for="userTelefono">Teléfono</label>
                         <input id="userTelefono" name="telefono" type="text" class="form-control" placeholder="+502..." />
                       </div>
-                      <div class="form-group col-md-4">
+                      <div class="form-group">
                         <label for="userRol">Rol</label>
                         <select id="userRol" name="rol_id" class="form-control" required>
                           <option value="">Selecciona rol</option>
                         </select>
                       </div>
-                      <div class="form-group col-md-4">
+                      <div class="form-group">
                         <label for="userEstado">Estado</label>
                         <select id="userEstado" name="estado" class="form-control">
                           <option value="activo">Activo</option>
@@ -687,12 +812,12 @@
                     </div>
 
                     <div class="form-row">
-                      <div class="form-group col-md-6">
+                      <div class="form-group">
                         <label for="userPassword">Contraseña temporal</label>
                         <input id="userPassword" name="password" type="password" class="form-control" placeholder="Opcional" autocomplete="new-password" />
                         <small class="form-text text-muted">Se almacenará como hash SHA-256. Úsala para restablecer accesos puntuales.</small>
                       </div>
-                      <div class="form-group col-md-6 align-self-end text-right">
+                      <div class="form-group form-actions">
                         <button class="btn btn-primary btn-sm" type="submit">Guardar usuario</button>
                         <button class="btn btn-link btn-sm text-danger" id="userReset" type="button">Cancelar</button>
                       </div>
@@ -729,11 +854,11 @@
                     <form id="roleForm" autocomplete="off">
                       <input type="hidden" name="rol_id" />
                       <div class="form-row">
-                        <div class="form-group col-md-6">
+                        <div class="form-group">
                           <label for="roleNombre">Nombre</label>
                           <input id="roleNombre" name="nombre" type="text" class="form-control" required />
                         </div>
-                        <div class="form-group col-md-6">
+                        <div class="form-group">
                           <label for="roleNivel">Nivel</label>
                           <input id="roleNivel" name="nivel" type="number" class="form-control" min="1" step="1" placeholder="1 = mayor prioridad" />
                           <small class="form-text text-muted">El nivel ayuda a ordenar jerarquías. Valores bajos indican mayor privilegio.</small>
@@ -743,7 +868,7 @@
                         <label for="roleDescripcion">Descripción</label>
                         <textarea id="roleDescripcion" name="descripcion" class="form-control" rows="2" placeholder="Ej. Gestiona inventarios y catálogos."></textarea>
                       </div>
-                      <div class="text-right">
+                      <div class="form-group form-actions">
                         <button class="btn btn-primary btn-sm" type="submit">Guardar rol</button>
                         <button class="btn btn-link btn-sm text-danger" id="roleReset" type="button">Cancelar</button>
                       </div>
@@ -773,20 +898,20 @@
                     <form id="permissionForm" autocomplete="off">
                       <input type="hidden" name="permiso_id" />
                       <div class="form-row">
-                        <div class="form-group col-md-4">
+                        <div class="form-group">
                           <label for="permisoCodigo">Código</label>
                           <input id="permisoCodigo" name="codigo" type="text" class="form-control" placeholder="inventario.listar" required />
                         </div>
-                        <div class="form-group col-md-4">
+                        <div class="form-group">
                           <label for="permisoCategoria">Categoría</label>
                           <input id="permisoCategoria" name="categoria" type="text" class="form-control" placeholder="Inventario" />
                         </div>
-                        <div class="form-group col-md-4">
+                        <div class="form-group">
                           <label for="permisoDescripcion">Descripción</label>
                           <input id="permisoDescripcion" name="descripcion" type="text" class="form-control" placeholder="Acceso a listado de productos" />
                         </div>
                       </div>
-                      <div class="text-right">
+                      <div class="form-group form-actions">
                         <button class="btn btn-primary btn-sm" type="submit">Guardar permiso</button>
                         <button class="btn btn-link btn-sm text-danger" id="permissionReset" type="button">Cancelar</button>
                       </div>
@@ -814,19 +939,19 @@
                   <div class="settings-subsection">
                     <h4>Asignación de permisos</h4>
                     <form id="rolePermissionForm" class="settings-inline" autocomplete="off">
-                      <div class="form-group mb-0">
+                      <div class="form-group">
                         <label for="rpRol">Rol</label>
                         <select id="rpRol" name="rol_id" class="form-control" required>
                           <option value="">Selecciona rol</option>
                         </select>
                       </div>
-                      <div class="form-group mb-0">
+                      <div class="form-group">
                         <label for="rpPermiso">Permiso</label>
                         <select id="rpPermiso" name="permiso_id" class="form-control" required>
                           <option value="">Selecciona permiso</option>
                         </select>
                       </div>
-                      <div class="form-group mb-0 align-self-end text-right">
+                      <div class="form-group form-actions">
                         <button class="btn btn-outline-primary btn-sm" type="submit">Asignar</button>
                       </div>
                     </form>
@@ -843,15 +968,15 @@
 
                   <div class="settings-subsection">
                     <form id="auditFilterForm" class="settings-inline" autocomplete="off">
-                      <div class="form-group mb-0">
+                      <div class="form-group">
                         <label for="auditEntidad">Entidad</label>
                         <input id="auditEntidad" name="entidad" type="text" class="form-control" placeholder="Ej. usuario" />
                       </div>
-                      <div class="form-group mb-0">
+                      <div class="form-group">
                         <label for="auditUsuario">Usuario</label>
                         <input id="auditUsuario" name="usuario" type="text" class="form-control" placeholder="ID o correo" />
                       </div>
-                      <div class="form-group mb-0 align-self-end text-right">
+                      <div class="form-group form-actions">
                         <button class="btn btn-outline-primary btn-sm" type="submit">Filtrar</button>
                         <button class="btn btn-link btn-sm" id="auditReset" type="button">Limpiar</button>
                       </div>


### PR DESCRIPTION
## Summary
- restyle the configuration forms with a custom grid and control styling so inputs stay contained and readable on all breakpoints
- normalize action button groups across roles, permisos y auditoría to keep buttons aligned without breaking the responsive stack

## Testing
- not run (front-end change only)


------
https://chatgpt.com/codex/tasks/task_e_68dde6d61a0c83258fcdca6eb8c62abe