### PR TITLE
Harmonize configuration module responsive styles

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -354,12 +354,63 @@
     .settings-panel form {
       background: rgba(242, 247, 255, 0.7);
       border-radius: 16px;
-      padding: 14px 16px;
+      padding: 16px 18px;
       margin-bottom: 18px;
+      display: grid;
+      gap: 16px;
+    }
+
+    .settings-panel form .form-row {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 16px;
+      margin: 0;
+    }
+
+    .settings-panel form .form-row > .form-group {
+      min-width: 0;
+    }
+
+    .settings-panel form .form-row > [class*='col-'] {
+      width: 100%;
+      max-width: none;
+      padding: 0;
     }
 
     .settings-panel form .form-group:last-child {
       margin-bottom: 0;
+    }
+
+    .settings-panel form .form-group.align-self-end,
+    .settings-inline .form-group.align-self-end {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      align-items: flex-end;
+      gap: 10px;
+    }
+
+    .settings-panel form .text-right {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      gap: 10px;
+    }
+
+    .settings-panel form .text-right .btn,
+    .settings-inline .form-group.text-right .btn,
+    .settings-panel form .form-group.align-self-end .btn,
+    .settings-inline .form-group.align-self-end .btn {
+      min-width: 140px;
+      flex: 0 0 auto;
+    }
+
+    .settings-panel .form-control,
+    .settings-panel textarea,
+    .settings-panel select {
+      width: 100%;
+      min-width: 0;
+      display: block;
     }
 
     .settings-panel table {
@@ -400,8 +451,43 @@
 
     .settings-inline {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 16px;
+      align-items: end;
+    }
+
+    .settings-inline .form-group {
+      margin-bottom: 0;
+      min-width: 0;
+    }
+
+    .settings-inline .form-group.text-right {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      gap: 10px;
+    }
+
+    .settings-panel form .text-right .btn-link,
+    .settings-inline .form-group.text-right .btn-link,
+    .settings-panel form .form-group.align-self-end .btn-link,
+    .settings-inline .form-group.align-self-end .btn-link {
+      min-width: auto;
+    }
+
+    .settings-panel .table-responsive {
+      width: 100%;
+      overflow-x: auto;
+      border-radius: 14px;
+    }
+
+    .settings-panel .table-responsive::-webkit-scrollbar {
+      height: 6px;
+    }
+
+    .settings-panel .table-responsive::-webkit-scrollbar-thumb {
+      background: rgba(30, 60, 114, 0.25);
+      border-radius: 999px;
     }
 
     .settings-empty {
@@ -503,6 +589,42 @@
 
       .section-card {
         padding: 18px;
+      }
+    }
+
+    @media (max-width: 576px) {
+      .settings-panel form {
+        padding: 14px 16px;
+      }
+
+      .settings-panel form .form-row {
+        grid-template-columns: 1fr;
+      }
+
+      .settings-inline {
+        grid-template-columns: 1fr;
+      }
+
+      .settings-panel form .text-right,
+      .settings-inline .form-group.text-right,
+      .settings-panel form .form-group.align-self-end,
+      .settings-inline .form-group.align-self-end {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .settings-panel form .text-right .btn,
+      .settings-inline .form-group.text-right .btn,
+      .settings-panel form .form-group.align-self-end .btn,
+      .settings-inline .form-group.align-self-end .btn {
+        width: 100%;
+      }
+
+      .settings-panel form .text-right .btn-link,
+      .settings-inline .form-group.text-right .btn-link,
+      .settings-panel form .form-group.align-self-end .btn-link,
+      .settings-inline .form-group.align-self-end .btn-link {
+        width: auto;
       }
     }
   </style>


### PR DESCRIPTION
## Summary
- align the configuration form action areas with shared flex rules so the buttons stay anchored inside their cards
- ensure settings inputs fill their columns and inline filters reflow cleanly with updated grid breakpoints
- add responsive table wrappers and mobile fallbacks to keep data within the panel on narrow screens

## Testing
- not run (static HTML/CSS change)

------
https://chatgpt.com/codex/tasks/task_e_68dde6d61a0c83258fcdca6eb8c62abe