### PR TITLE
Visualize Joyeria dataset in admin dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Js/config.js

--- a/Js/admin-dashboard-data.js
+++ b/Js/admin-dashboard-data.js
@@ -1,0 +1,619 @@
+const dataset = {
+  roles: [
+    { id: 1, nombre: 'Administrador' },
+    { id: 2, nombre: 'Vendedor' },
+    { id: 3, nombre: 'Inventario' },
+    { id: 4, nombre: 'Cliente' }
+  ],
+  permisos: [
+    { id: 1, nombre: 'gestionar_usuarios' },
+    { id: 2, nombre: 'gestionar_productos' },
+    { id: 3, nombre: 'ver_reportes' },
+    { id: 4, nombre: 'realizar_ventas' },
+    { id: 5, nombre: 'gestionar_inventario' }
+  ],
+  rolPermisos: [
+    { rolId: 1, permisoId: 1 },
+    { rolId: 1, permisoId: 2 },
+    { rolId: 1, permisoId: 3 },
+    { rolId: 1, permisoId: 4 },
+    { rolId: 1, permisoId: 5 },
+    { rolId: 2, permisoId: 4 },
+    { rolId: 2, permisoId: 3 },
+    { rolId: 3, permisoId: 2 },
+    { rolId: 3, permisoId: 5 }
+  ],
+  usuarios: [
+    { id: 1, nombre: 'María González', email: 'maria@joyeriamares.com', telefono: '+502 1111-2222', passwordHash: 'sha256$abc123', rolId: 1, estado: 'Activo' },
+    { id: 2, nombre: 'Carlos López', email: 'carlos@joyeriamares.com', telefono: '+502 3333-4444', passwordHash: 'sha256$def456', rolId: 2, estado: 'Activo' },
+    { id: 3, nombre: 'Ana Martínez', email: 'ana@joyeriamares.com', telefono: '+502 5555-6666', passwordHash: 'sha256$ghi789', rolId: 3, estado: 'Activo' }
+  ],
+  bitacoraAccion: [
+    { usuarioId: 1, accion: 'Inició sesión en el sistema' },
+    { usuarioId: 2, accion: 'Realizó venta #001' },
+    { usuarioId: 1, accion: 'Actualizó producto #1' }
+  ],
+  auditoria: [
+    { usuarioId: 1, descripcion: 'Creación de nuevo usuario: Carlos López' },
+    { usuarioId: 2, descripcion: 'Venta registrada: ORD-001' },
+    { usuarioId: 3, descripcion: 'Ajuste de inventario: Producto #1' }
+  ],
+  categorias: [
+    { id: 1, nombre: 'Anillos' },
+    { id: 2, nombre: 'Collares' },
+    { id: 3, nombre: 'Pulseras' },
+    { id: 4, nombre: 'Aretes' },
+    { id: 5, nombre: 'Relojes' }
+  ],
+  materiales: [
+    { id: 1, nombre: 'Oro 18k' },
+    { id: 2, nombre: 'Plata 925' },
+    { id: 3, nombre: 'Acero Inoxidable' },
+    { id: 4, nombre: 'Oro Blanco' },
+    { id: 5, nombre: 'Titanio' }
+  ],
+  productos: [
+    { id: 1, nombre: 'Anillo Solitario Diamante', descripcion: 'Anillo en oro 18k con diamante central 0.5ct', precio: 2500.0, stock: 5, categoriaId: 1 },
+    { id: 2, nombre: 'Collar Corazón Plata', descripcion: 'Collar de plata 925 con dije corazón', precio: 450.0, stock: 12, categoriaId: 2 },
+    { id: 3, nombre: 'Pulsera Eslabones Oro', descripcion: 'Pulsera en oro 18k con eslabones entrelazados', precio: 1800.0, stock: 8, categoriaId: 3 },
+    { id: 4, nombre: 'Aretes Florales', descripcion: 'Aretes de plata con diseño floral', precio: 280.0, stock: 15, categoriaId: 4 },
+    { id: 5, nombre: 'Reloj Deportivo', descripcion: 'Reloj acero inoxidable resistente al agua', precio: 1200.0, stock: 6, categoriaId: 5 }
+  ],
+  productoMaterial: [
+    { productoId: 1, materialId: 1, porcentaje: 100 },
+    { productoId: 2, materialId: 2, porcentaje: 100 },
+    { productoId: 3, materialId: 1, porcentaje: 100 },
+    { productoId: 4, materialId: 2, porcentaje: 100 },
+    { productoId: 5, materialId: 3, porcentaje: 100 }
+  ],
+  imagenesProducto: [
+    { productoId: 1, url: '/uploads/anillo-diamante-1.jpg' },
+    { productoId: 2, url: '/uploads/collar-corazon-1.jpg' },
+    { productoId: 3, url: '/uploads/pulsera-eslabones-1.jpg' },
+    { productoId: 4, url: '/uploads/aretes-florales-1.jpg' },
+    { productoId: 5, url: '/uploads/reloj-deportivo-1.jpg' }
+  ],
+  inventarioMovimientos: [
+    { productoId: 1, tipo: 'entrada', cantidad: 10 },
+    { productoId: 2, tipo: 'entrada', cantidad: 20 },
+    { productoId: 1, tipo: 'salida', cantidad: 5 },
+    { productoId: 2, tipo: 'salida', cantidad: 8 },
+    { productoId: 3, tipo: 'entrada', cantidad: 15 }
+  ],
+  clientes: [
+    { id: 1, nombre: 'Laura Hernández', email: 'laura.h@email.com', telefono: '+502 1234-5678' },
+    { id: 2, nombre: 'Roberto Morales', email: 'roberto.m@email.com', telefono: '+502 2345-6789' },
+    { id: 3, nombre: 'Sofia Ramírez', email: 'sofia.r@email.com', telefono: '+502 3456-7890' },
+    { id: 4, nombre: 'Diego Castillo', email: 'diego.c@email.com', telefono: '+502 4567-8901' }
+  ],
+  direccionesCliente: [
+    { clienteId: 1, tipo: 'envio', direccion: '12 Avenida 5-67, Zona 10, Ciudad de Guatemala' },
+    { clienteId: 1, tipo: 'facturacion', direccion: '12 Avenida 5-67, Zona 10, Ciudad de Guatemala' },
+    { clienteId: 2, tipo: 'envio', direccion: '8 Calle 3-45, Zona 1, Mixco' },
+    { clienteId: 3, tipo: 'envio', direccion: '15 Calle 8-23, Zona 15, Guatemala' }
+  ],
+  eventosCliente: [
+    { clienteId: 1, tipo: 'cumpleaños', fecha: '2024-06-15' },
+    { clienteId: 2, tipo: 'aniversario', fecha: '2024-07-20' },
+    { clienteId: 3, tipo: 'cumpleaños', fecha: '2024-08-10' }
+  ],
+  notificaciones: [
+    { id: 1, titulo: 'Oferta Especial', mensaje: 'Descuento del 20% en toda la colección de verano' },
+    { id: 2, titulo: 'Nuevos Productos', mensaje: 'Descubre nuestra nueva línea de joyería vintage' },
+    { id: 3, titulo: 'Recordatorio de Evento', mensaje: 'No te pierdas nuestro evento exclusivo este sábado' }
+  ],
+  clienteNotificacion: [
+    { clienteId: 1, notificacionId: 1 },
+    { clienteId: 2, notificacionId: 1 },
+    { clienteId: 3, notificacionId: 1 },
+    { clienteId: 4, notificacionId: 1 },
+    { clienteId: 1, notificacionId: 2 },
+    { clienteId: 3, notificacionId: 2 }
+  ],
+  chatbotLogs: [
+    { clienteId: 1, mensaje: 'Consulta sobre anillos de compromiso' },
+    { clienteId: 2, mensaje: 'Pregunta sobre garantía de productos' },
+    { clienteId: 3, mensaje: 'Solicitud de catálogo completo' }
+  ],
+  carritos: [
+    { id: 1, clienteId: 1 },
+    { id: 2, clienteId: 2 },
+    { id: 3, clienteId: 3 }
+  ],
+  carritoDetalle: [
+    { carritoId: 1, productoId: 1, cantidad: 1, precioUnitario: 2500.0 },
+    { carritoId: 1, productoId: 2, cantidad: 1, precioUnitario: 450.0 },
+    { carritoId: 2, productoId: 3, cantidad: 1, precioUnitario: 1800.0 },
+    { carritoId: 3, productoId: 4, cantidad: 2, precioUnitario: 280.0 }
+  ],
+  ordenes: [
+    { id: 1, clienteId: 1, estado: 'pagado', total: 2950.0 },
+    { id: 2, clienteId: 2, estado: 'enviado', total: 1800.0 },
+    { id: 3, clienteId: 3, estado: 'pendiente', total: 560.0 }
+  ],
+  ordenDetalle: [
+    { id: 1, ordenId: 1, productoId: 1, cantidad: 1, precioUnitario: 2500.0 },
+    { id: 2, ordenId: 1, productoId: 2, cantidad: 1, precioUnitario: 450.0 },
+    { id: 3, ordenId: 2, productoId: 3, cantidad: 1, precioUnitario: 1800.0 },
+    { id: 4, ordenId: 3, productoId: 4, cantidad: 2, precioUnitario: 280.0 }
+  ],
+  devoluciones: [
+    { ordenDetalleId: 1, motivo: 'Talla incorrecta' }
+  ],
+  metodosPago: [
+    { id: 1, nombre: 'Tarjeta de Crédito' },
+    { id: 2, nombre: 'Tarjeta de Débito' },
+    { id: 3, nombre: 'Transferencia Bancaria' },
+    { id: 4, nombre: 'Efectivo' },
+    { id: 5, nombre: 'PayPal' }
+  ],
+  pagos: [
+    { id: 1, ordenId: 1, monto: 2950.0, estado: 'completado' },
+    { id: 2, ordenId: 2, monto: 1800.0, estado: 'completado' },
+    { id: 3, ordenId: 3, monto: 560.0, estado: 'pendiente' }
+  ],
+  ordenMetodoPago: [
+    { ordenId: 1, metodoId: 1, monto: 2950.0 },
+    { ordenId: 2, metodoId: 3, monto: 1800.0 },
+    { ordenId: 3, metodoId: 4, monto: 560.0 }
+  ],
+  comprobantesPago: [
+    { pagoId: 1, url: '/comprobantes/pago-001.pdf' },
+    { pagoId: 2, url: '/comprobantes/pago-002.pdf' }
+  ],
+  proveedores: [
+    { id: 1, nombre: 'Joyas Internacionales S.A.', nit: '123456-7', telefono: '+502 5555-1234', direccion: 'Centro Comercial Miraflores, Local 45' },
+    { id: 2, nombre: 'Metales Preciosos GT', nit: '765432-1', telefono: '+502 5555-5678', direccion: '5a Avenida 8-90, Zona 4' },
+    { id: 3, nombre: 'Relojería Europea', nit: '987654-3', telefono: '+502 5555-9012', direccion: 'Plaza Fontabella, Nivel 2' }
+  ],
+  proveedorProducto: [
+    { proveedorId: 1, productoId: 1, costo: 1800.0, tiempoEntrega: 15 },
+    { proveedorId: 1, productoId: 3, costo: 1200.0, tiempoEntrega: 10 },
+    { proveedorId: 2, productoId: 2, costo: 300.0, tiempoEntrega: 7 },
+    { proveedorId: 2, productoId: 4, costo: 180.0, tiempoEntrega: 5 },
+    { proveedorId: 3, productoId: 5, costo: 800.0, tiempoEntrega: 20 }
+  ],
+  compras: [
+    { id: 1, proveedorId: 1, total: 3000.0 },
+    { id: 2, proveedorId: 2, total: 960.0 }
+  ],
+  compraDetalle: [
+    { compraId: 1, productoId: 1, cantidad: 1, precioUnitario: 1800.0 },
+    { compraId: 1, productoId: 3, cantidad: 1, precioUnitario: 1200.0 },
+    { compraId: 2, productoId: 2, cantidad: 2, precioUnitario: 300.0 },
+    { compraId: 2, productoId: 4, cantidad: 2, precioUnitario: 180.0 }
+  ],
+  transportistas: [
+    { id: 1, nombre: 'Servicios Express GT', telefono: '+502 5555-4444' },
+    { id: 2, nombre: 'Mensajería Rápida', telefono: '+502 5555-5555' },
+    { id: 3, nombre: 'Envíos Nacionales', telefono: '+502 5555-6666' }
+  ],
+  envios: [
+    { id: 1, ordenId: 1, transportistaId: 1, estado: 'entregado', tracking: 'TRK001234567' },
+    { id: 2, ordenId: 2, transportistaId: 2, estado: 'enviado', tracking: 'TRK001234568' },
+    { id: 3, ordenId: 3, transportistaId: 3, estado: 'pendiente', tracking: null }
+  ],
+  envioDetalle: [
+    { envioId: 1, productoId: 1, cantidad: 1 },
+    { envioId: 1, productoId: 2, cantidad: 1 },
+    { envioId: 2, productoId: 3, cantidad: 1 },
+    { envioId: 3, productoId: 4, cantidad: 2 }
+  ],
+  reportesKpi: [
+    { nombre: 'Ventas del Mes', valor: 'Q45,800.00' },
+    { nombre: 'Productos Vendidos', valor: '156 unidades' },
+    { nombre: 'Clientes Nuevos', valor: '23 clientes' },
+    { nombre: 'Tasa de Conversión', valor: '4.5%' },
+    { nombre: 'Inventario Valorizado', valor: 'Q189,500.00' }
+  ]
+};
+
+const money = new Intl.NumberFormat('es-GT', { style: 'currency', currency: 'GTQ' });
+const number = new Intl.NumberFormat('es-GT');
+
+function humanize(text) {
+  if (!text) return '';
+  return text
+    .toString()
+    .replace(/_/g, ' ')
+    .replace(/\w+/g, word => word.charAt(0).toUpperCase() + word.slice(1));
+}
+
+function fillTable(tableId, rows, renderRow, emptyMessage = 'Sin datos registrados.') {
+  const table = document.getElementById(tableId);
+  if (!table) return;
+  const tbody = table.querySelector('tbody');
+  if (!tbody) return;
+
+  if (!rows || !rows.length) {
+    const cols = table.querySelectorAll('thead th').length || 1;
+    tbody.innerHTML = `<tr><td colspan="${cols}" class="text-center text-muted py-3">${emptyMessage}</td></tr>`;
+    return;
+  }
+
+  tbody.innerHTML = rows.map(renderRow).join('');
+}
+
+function renderInfoCards(containerId, cards) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  container.innerHTML = cards
+    .map(card => `
+      <article class="info-card">
+        <h3>${card.title}</h3>
+        <strong>${card.value}</strong>
+        <span>${card.caption}</span>
+      </article>
+    `)
+    .join('');
+}
+
+function renderDashboard() {
+  renderInfoCards('dashboardKpiGrid', dataset.reportesKpi.map(kpi => ({
+    title: kpi.nombre,
+    value: kpi.valor,
+    caption: 'Dato proveniente de reportes_kpi'
+  })));
+
+  const permisoMap = new Map(dataset.permisos.map(p => [p.id, p]));
+  const rolRows = dataset.roles.map(rol => {
+    const permisos = dataset.rolPermisos
+      .filter(rp => rp.rolId === rol.id)
+      .map(rp => humanize(permisoMap.get(rp.permisoId)?.nombre ?? ''));
+    return {
+      rol: rol.nombre,
+      permisos: permisos.length ? permisos.join(', ') : 'Sin permisos asignados'
+    };
+  });
+
+  fillTable('dashboardRolesTable', rolRows, row => `
+    <tr>
+      <td>${row.rol}</td>
+      <td>${row.permisos}</td>
+    </tr>
+  `);
+
+  fillTable('dashboardPermisosTable', dataset.permisos, permiso => `
+    <tr>
+      <td>${humanize(permiso.nombre)}</td>
+      <td>${permiso.nombre.includes('_') ? `Permite ${humanize(permiso.nombre).toLowerCase()}` : 'Permiso operativo'}</td>
+    </tr>
+  `);
+
+  const rolMap = new Map(dataset.roles.map(r => [r.id, r.nombre]));
+  fillTable('dashboardUsuariosTable', dataset.usuarios, usuario => `
+    <tr>
+      <td>${usuario.nombre}</td>
+      <td>${usuario.email}</td>
+      <td>${rolMap.get(usuario.rolId) ?? '—'}</td>
+      <td>${usuario.estado}</td>
+    </tr>
+  `);
+
+  fillTable('dashboardBitacoraTable', dataset.bitacoraAccion, bitacora => `
+    <tr>
+      <td>${dataset.usuarios.find(u => u.id === bitacora.usuarioId)?.nombre ?? '—'}</td>
+      <td>${bitacora.accion}</td>
+    </tr>
+  `);
+
+  fillTable('dashboardAuditoriaTable', dataset.auditoria, registro => `
+    <tr>
+      <td>${dataset.usuarios.find(u => u.id === registro.usuarioId)?.nombre ?? '—'}</td>
+      <td>${registro.descripcion}</td>
+    </tr>
+  `);
+}
+
+function renderProductos() {
+  const stockTotal = dataset.productos.reduce((acc, p) => acc + p.stock, 0);
+  const valorInventario = dataset.productos.reduce((acc, p) => acc + p.precio * p.stock, 0);
+  const entradas = dataset.inventarioMovimientos.filter(m => m.tipo === 'entrada').reduce((acc, m) => acc + m.cantidad, 0);
+  const salidas = dataset.inventarioMovimientos.filter(m => m.tipo === 'salida').reduce((acc, m) => acc + m.cantidad, 0);
+
+  renderInfoCards('productSummaryCards', [
+    { title: 'Productos activos', value: number.format(dataset.productos.length), caption: 'Registros en catálogo' },
+    { title: 'Stock disponible', value: number.format(stockTotal) + ' uds', caption: 'Unidades totales' },
+    { title: 'Valor inventario', value: money.format(valorInventario), caption: 'Precio x stock actual' },
+    { title: 'Movimientos netos', value: number.format(entradas - salidas) + ' uds', caption: 'Entradas menos salidas' }
+  ]);
+
+  const categoriaMap = new Map(dataset.categorias.map(c => [c.id, c.nombre]));
+  const productoMaterialMap = new Map(dataset.productoMaterial.map(pm => [pm.productoId, pm.materialId]));
+  const materialMap = new Map(dataset.materiales.map(m => [m.id, m.nombre]));
+
+  const productoRows = dataset.productos.map(producto => ({
+    nombre: producto.nombre,
+    categoria: categoriaMap.get(producto.categoriaId) ?? '—',
+    material: materialMap.get(productoMaterialMap.get(producto.id) ?? null) ?? '—',
+    precio: producto.precio,
+    stock: producto.stock
+  }));
+
+  fillTable('datasetProductosTable', productoRows, row => `
+    <tr>
+      <td>${row.nombre}</td>
+      <td>${row.categoria}</td>
+      <td>${row.material}</td>
+      <td>${money.format(row.precio)}</td>
+      <td>${number.format(row.stock)}</td>
+    </tr>
+  `);
+
+  const categoriaRows = dataset.categorias.map(cat => {
+    const count = dataset.productos.filter(p => p.categoriaId === cat.id).length;
+    return { nombre: cat.nombre, count };
+  });
+  fillTable('datasetCategoriasTable', categoriaRows, row => `
+    <tr>
+      <td>${row.nombre}</td>
+      <td>${number.format(row.count)}</td>
+    </tr>
+  `);
+
+  const materialRows = dataset.materiales.map(mat => {
+    const productoRelacionado = dataset.productoMaterial.find(pm => pm.materialId === mat.id);
+    const productoNombre = productoRelacionado ? dataset.productos.find(p => p.id === productoRelacionado.productoId)?.nombre : null;
+    return {
+      nombre: mat.nombre,
+      uso: productoNombre ?? 'Pendiente de asignación'
+    };
+  });
+  fillTable('datasetMaterialesTable', materialRows, row => `
+    <tr>
+      <td>${row.nombre}</td>
+      <td>${row.uso}</td>
+    </tr>
+  `);
+
+  const movimientoRows = dataset.inventarioMovimientos.map(mov => ({
+    producto: dataset.productos.find(p => p.id === mov.productoId)?.nombre ?? '—',
+    tipo: humanize(mov.tipo),
+    cantidad: mov.cantidad
+  }));
+  fillTable('datasetMovimientosTable', movimientoRows, row => `
+    <tr>
+      <td>${row.producto}</td>
+      <td>${row.tipo}</td>
+      <td>${number.format(row.cantidad)}</td>
+    </tr>
+  `);
+}
+
+function renderVentas() {
+  const totalClientes = dataset.clientes.length;
+  const totalCarritos = dataset.carritos.length;
+  const totalOrdenes = dataset.ordenes.length;
+  const totalIngresos = dataset.ordenes.reduce((acc, ord) => acc + ord.total, 0);
+
+  const completadas = dataset.ordenes.filter(o => {
+    const estado = (o.estado ?? '').toString().toLowerCase();
+    return ['pagado', 'enviado', 'entregado'].includes(estado);
+  }).length;
+
+  renderInfoCards('salesSummaryCards', [
+    { title: 'Clientes activos', value: number.format(totalClientes), caption: 'Registrados en CRM' },
+    { title: 'Carritos abiertos', value: number.format(totalCarritos), caption: 'En seguimiento' },
+    { title: 'Órdenes generadas', value: number.format(totalOrdenes), caption: `${number.format(completadas)} completadas` },
+    { title: 'Ventas proyectadas', value: money.format(totalIngresos), caption: 'Total órdenes registradas' }
+  ]);
+
+  fillTable('salesClientesTable', dataset.clientes, cliente => `
+    <tr>
+      <td>${cliente.nombre}</td>
+      <td>${cliente.email}</td>
+      <td>${cliente.telefono}</td>
+    </tr>
+  `);
+
+  const eventosRows = dataset.eventosCliente.map(evento => {
+    const cliente = dataset.clientes.find(c => c.id === evento.clienteId)?.nombre ?? '—';
+    const fechaObj = new Date(`${evento.fecha}T00:00:00`);
+    const fecha = Number.isNaN(fechaObj.getTime()) ? evento.fecha : fechaObj.toLocaleDateString('es-GT');
+    return {
+      cliente,
+      tipo: humanize(evento.tipo),
+      fecha
+    };
+  });
+  fillTable('salesEventosTable', eventosRows, row => `
+    <tr>
+      <td>${row.tipo} - ${row.cliente}</td>
+      <td>${row.fecha}</td>
+    </tr>
+  `);
+
+  const notificacionAudiencia = dataset.notificaciones.map(notificacion => {
+    const audiencia = dataset.clienteNotificacion.filter(cn => cn.notificacionId === notificacion.id).length;
+    return {
+      titulo: notificacion.titulo,
+      audiencia
+    };
+  });
+  fillTable('salesNotificacionesTable', notificacionAudiencia, row => `
+    <tr>
+      <td>${row.titulo}</td>
+      <td>${number.format(row.audiencia)} clientes</td>
+    </tr>
+  `);
+
+  const chatbotRows = dataset.chatbotLogs.map(log => ({
+    cliente: dataset.clientes.find(c => c.id === log.clienteId)?.nombre ?? '—',
+    mensaje: log.mensaje
+  }));
+  fillTable('salesChatbotTable', chatbotRows, row => `
+    <tr>
+      <td>${row.cliente}</td>
+      <td>${row.mensaje}</td>
+    </tr>
+  `);
+
+  const ordenRows = dataset.ordenes.map(orden => ({
+    orden: `ORD-${orden.id.toString().padStart(3, '0')}`,
+    cliente: dataset.clientes.find(c => c.id === orden.clienteId)?.nombre ?? '—',
+    estado: humanize(orden.estado),
+    total: orden.total
+  }));
+  fillTable('salesOrdenesTable', ordenRows, row => `
+    <tr>
+      <td>${row.orden}</td>
+      <td>${row.cliente}</td>
+      <td>${row.estado}</td>
+      <td>${money.format(row.total)}</td>
+    </tr>
+  `);
+
+  const detalleRows = dataset.ordenDetalle.map(det => ({
+    orden: `ORD-${det.ordenId.toString().padStart(3, '0')}`,
+    producto: dataset.productos.find(p => p.id === det.productoId)?.nombre ?? '—',
+    cantidad: det.cantidad,
+    precio: det.precioUnitario
+  }));
+  fillTable('salesDetalleTable', detalleRows, row => `
+    <tr>
+      <td>${row.orden}</td>
+      <td>${row.producto}</td>
+      <td>${number.format(row.cantidad)}</td>
+      <td>${money.format(row.precio)}</td>
+    </tr>
+  `);
+
+  const devolucionRows = dataset.devoluciones.map(dev => {
+    const detalle = dataset.ordenDetalle.find(det => det.id === dev.ordenDetalleId);
+    const ordenId = detalle?.ordenId;
+    const producto = detalle ? dataset.productos.find(p => p.id === detalle.productoId)?.nombre : null;
+    return {
+      orden: ordenId ? `ORD-${ordenId.toString().padStart(3, '0')}` : '—',
+      motivo: producto ? `${dev.motivo} · ${producto}` : dev.motivo
+    };
+  });
+  fillTable('salesDevolucionesTable', devolucionRows, row => `
+    <tr>
+      <td>${row.orden}</td>
+      <td>${row.motivo}</td>
+    </tr>
+  `);
+}
+
+function renderIngresos() {
+  const ingresosCompletados = dataset.pagos.filter(p => p.estado === 'completado').reduce((acc, pago) => acc + pago.monto, 0);
+  const ingresosPendientes = dataset.pagos.filter(p => p.estado !== 'completado').reduce((acc, pago) => acc + pago.monto, 0);
+  const comprasTotal = dataset.compras.reduce((acc, compra) => acc + compra.total, 0);
+  const enviosEnCurso = dataset.envios.filter(envio => (envio.estado ?? '').toString().toLowerCase() !== 'entregado').length;
+
+  renderInfoCards('revenueSummaryCards', [
+    { title: 'Ingresos confirmados', value: money.format(ingresosCompletados), caption: 'Pagos en estado completado' },
+    { title: 'Cobros pendientes', value: money.format(ingresosPendientes), caption: 'Pagos por finalizar' },
+    { title: 'Compras realizadas', value: money.format(comprasTotal), caption: 'Inversión en inventario' },
+    { title: 'Envíos activos', value: number.format(enviosEnCurso), caption: 'Pedidos en proceso logístico' }
+  ]);
+
+  fillTable('revenuePagosTable', dataset.pagos, pago => `
+    <tr>
+      <td>ORD-${pago.ordenId.toString().padStart(3, '0')}</td>
+      <td>${money.format(pago.monto)}</td>
+      <td>${humanize(pago.estado)}</td>
+    </tr>
+  `);
+
+  fillTable('revenueOrdenMetodoTable', dataset.ordenMetodoPago, registro => `
+    <tr>
+      <td>ORD-${registro.ordenId.toString().padStart(3, '0')}</td>
+      <td>${dataset.metodosPago.find(m => m.id === registro.metodoId)?.nombre ?? '—'}</td>
+      <td>${money.format(registro.monto)}</td>
+    </tr>
+  `);
+
+  const metodoUso = dataset.metodosPago.map(metodo => {
+    const usos = dataset.ordenMetodoPago.filter(omp => omp.metodoId === metodo.id).length;
+    return {
+      nombre: metodo.nombre,
+      disponibilidad: usos ? `${number.format(usos)} órdenes` : 'Disponible'
+    };
+  });
+  fillTable('revenueMetodosTable', metodoUso, row => `
+    <tr>
+      <td>${row.nombre}</td>
+      <td>${row.disponibilidad}</td>
+    </tr>
+  `);
+
+  fillTable('revenueComprobantesTable', dataset.comprobantesPago, comprobante => {
+    const pago = dataset.pagos.find(p => p.id === comprobante.pagoId);
+    return `
+      <tr>
+        <td>Pago #${comprobante.pagoId} (${pago ? money.format(pago.monto) : '—'})</td>
+        <td><a href="${comprobante.url}" target="_blank" rel="noopener">${comprobante.url}</a></td>
+      </tr>
+    `;
+  });
+
+  const compraRows = dataset.compras.map(compra => ({
+    compra: `COMP-${compra.id.toString().padStart(3, '0')}`,
+    proveedor: dataset.proveedores.find(p => p.id === compra.proveedorId)?.nombre ?? '—',
+    total: compra.total
+  }));
+  fillTable('revenueComprasTable', compraRows, row => `
+    <tr>
+      <td>${row.compra}</td>
+      <td>${row.proveedor}</td>
+      <td>${money.format(row.total)}</td>
+    </tr>
+  `);
+
+  const compraDetalleRows = dataset.compraDetalle.map(det => ({
+    compra: `COMP-${det.compraId.toString().padStart(3, '0')}`,
+    producto: dataset.productos.find(p => p.id === det.productoId)?.nombre ?? '—',
+    cantidad: det.cantidad,
+    precio: det.precioUnitario
+  }));
+  fillTable('revenueCompraDetalleTable', compraDetalleRows, row => `
+    <tr>
+      <td>${row.compra}</td>
+      <td>${row.producto}</td>
+      <td>${number.format(row.cantidad)}</td>
+      <td>${money.format(row.precio)}</td>
+    </tr>
+  `);
+
+  const enviosRows = dataset.envios.map(envio => ({
+    orden: `ORD-${envio.ordenId.toString().padStart(3, '0')}`,
+    transportista: dataset.transportistas.find(t => t.id === envio.transportistaId)?.nombre ?? '—',
+    estado: humanize(envio.estado),
+    tracking: envio.tracking ?? '—'
+  }));
+  fillTable('revenueEnviosTable', enviosRows, row => `
+    <tr>
+      <td>${row.orden}</td>
+      <td>${row.transportista}</td>
+      <td>${row.estado}</td>
+      <td>${row.tracking}</td>
+    </tr>
+  `);
+
+  const envioDetalleRows = dataset.envioDetalle.map(det => ({
+    envio: `ENV-${det.envioId.toString().padStart(3, '0')}`,
+    producto: dataset.productos.find(p => p.id === det.productoId)?.nombre ?? '—',
+    cantidad: det.cantidad
+  }));
+  fillTable('revenueEnvioDetalleTable', envioDetalleRows, row => `
+    <tr>
+      <td>${row.envio}</td>
+      <td>${row.producto}</td>
+      <td>${number.format(row.cantidad)}</td>
+    </tr>
+  `);
+}
+
+function renderDataset() {
+  renderDashboard();
+  renderProductos();
+  renderVentas();
+  renderIngresos();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', renderDataset);
+} else {
+  renderDataset();
+}

--- a/Js/config.sample.js
+++ b/Js/config.sample.js
@@ -1,0 +1,8 @@
+// Copia este archivo como "Js/config.js" y reemplaza los valores por las credenciales
+// de tu proyecto en https://app.supabase.com. Nunca compartas la service_role key en
+// el frontend, únicamente la anon key pública.
+
+window.APP_CONFIG = {
+  supabaseUrl: 'https://iqpgmxoeovuhpfbqjqme.supabase.co',
+  supabaseAnonKey: 'REEMPLAZA_CON_TU_SUPABASE_ANON_KEY'
+};

--- a/Js/settings.js
+++ b/Js/settings.js
@@ -1,0 +1,783 @@
+/**
+ * Panel de configuración conectado a Supabase.
+ * Tablas esperadas:
+ *  - usuario: usuario_id (PK), nombre, email, telefono, rol_id (FK rol.rol_id), estado, password_hash, ultimo_acceso.
+ *  - rol: rol_id (PK), nombre, descripcion, nivel.
+ *  - permiso: permiso_id (PK), codigo, categoria, descripcion.
+ *  - rol_permiso: (PK opcional), rol_id, permiso_id.
+ *  - auditoria: auditoria_id (PK), entidad, accion, detalle, usuario/usuario_id/usuario_email, fecha/timestamp.
+ */
+const settingsWrapper = document.getElementById('settingsWrapper');
+const settingsStatus = document.getElementById('settingsStatus');
+const settingsPlaceholder = document.getElementById('settingsPlaceholder');
+
+const state = {
+  users: [],
+  roles: [],
+  permissions: [],
+  rolePermissions: [],
+  auditRaw: [],
+  audit: [],
+  auditFilters: {
+    entidad: '',
+    usuario: ''
+  }
+};
+
+let client = null;
+
+function showStatus(message, type = 'info', timeout = 4500) {
+  if (!settingsStatus) return;
+  settingsStatus.textContent = message;
+  settingsStatus.classList.toggle('error', type === 'error');
+  settingsStatus.style.display = 'block';
+
+  window.clearTimeout(showStatus._timeoutId);
+  if (timeout && timeout > 0) {
+    showStatus._timeoutId = window.setTimeout(() => {
+      settingsStatus.style.display = 'none';
+    }, timeout);
+  }
+}
+
+function hideStatus() {
+  if (!settingsStatus) return;
+  window.clearTimeout(showStatus._timeoutId);
+  settingsStatus.style.display = 'none';
+}
+
+function setPlaceholderVisible(visible) {
+  if (!settingsPlaceholder) return;
+  if (visible) {
+    settingsPlaceholder.hidden = false;
+    settingsPlaceholder.style.display = '';
+  } else {
+    settingsPlaceholder.hidden = true;
+    settingsPlaceholder.style.display = 'none';
+  }
+}
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function nullableValue(value) {
+  const cleaned = normalizeString(value);
+  return cleaned ? cleaned : null;
+}
+
+function firstAvailable(obj, candidates, fallback = undefined) {
+  if (!obj) return fallback;
+  for (const key of candidates) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const value = obj[key];
+      if (value !== null && value !== undefined) {
+        return value;
+      }
+    }
+  }
+  return fallback;
+}
+
+function formatDateTime(value) {
+  if (!value) return '';
+  let date = value;
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) {
+      date = new Date(parsed);
+    }
+  }
+  if (typeof date === 'number') {
+    date = new Date(date);
+  }
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+  return new Intl.DateTimeFormat('es-GT', {
+    dateStyle: 'short',
+    timeStyle: 'short'
+  }).format(date);
+}
+
+async function hashPassword(plain) {
+  if (!plain) return null;
+  const encoder = new TextEncoder();
+  const data = encoder.encode(plain);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map(byte => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function renderUsers() {
+  const tbody = settingsWrapper?.querySelector('[data-users-body]');
+  if (!tbody) return;
+
+  if (!state.users.length) {
+    tbody.innerHTML = '<tr><td colspan="6" class="settings-empty">Sin usuarios registrados todavía.</td></tr>';
+    return;
+  }
+
+  const rows = state.users.map(user => {
+    const id = firstAvailable(user, ['usuario_id', 'id']);
+    const roleId = firstAvailable(user, ['rol_id', 'role_id']);
+    const roleName = state.roles.find(r => firstAvailable(r, ['rol_id', 'id']) === roleId)?.nombre ?? '—';
+    const status = normalizeString(firstAvailable(user, ['estado', 'status', 'activo'])) || 'activo';
+    const lastAccess = firstAvailable(user, ['ultimo_acceso', 'last_login_at', 'updated_at', 'fecha_acceso']);
+
+    return `
+      <tr data-id="${id ?? ''}">
+        <td>${user.nombre ?? user.name ?? '—'}</td>
+        <td>${user.email ?? '—'}</td>
+        <td>${roleName}</td>
+        <td class="text-capitalize">${status}</td>
+        <td>${lastAccess ? formatDateTime(lastAccess) : '—'}</td>
+        <td class="text-right">
+          <button class="btn btn-link btn-sm" data-action="edit" data-id="${id}">Editar</button>
+          <button class="btn btn-link btn-sm text-danger" data-action="delete" data-id="${id}">Eliminar</button>
+        </td>
+      </tr>
+    `;
+  });
+
+  tbody.innerHTML = rows.join('');
+}
+
+function renderRoles() {
+  const tbody = settingsWrapper?.querySelector('[data-roles-body]');
+  const userRoleSelect = document.getElementById('userRol');
+  const rpRolSelect = document.getElementById('rpRol');
+
+  if (tbody) {
+    if (!state.roles.length) {
+      tbody.innerHTML = '<tr><td colspan="4" class="settings-empty">Sin roles disponibles.</td></tr>';
+    } else {
+      tbody.innerHTML = state.roles
+        .map(role => {
+          const id = firstAvailable(role, ['rol_id', 'id']);
+          const nivel = firstAvailable(role, ['nivel', 'priority']);
+          const descripcion = firstAvailable(role, ['descripcion', 'description']);
+          return `
+            <tr data-id="${id ?? ''}">
+              <td>${role.nombre ?? role.name ?? '—'}</td>
+              <td>${nivel ?? '—'}</td>
+              <td>${descripcion ?? '—'}</td>
+              <td class="text-right">
+                <button class="btn btn-link btn-sm" data-action="edit" data-id="${id}">Editar</button>
+                <button class="btn btn-link btn-sm text-danger" data-action="delete" data-id="${id}">Eliminar</button>
+              </td>
+            </tr>
+          `;
+        })
+        .join('');
+    }
+  }
+
+  const buildOptions = (select) => {
+    if (!select) return;
+    const currentValue = select.value;
+    select.innerHTML = '<option value="">Selecciona rol</option>' +
+      state.roles
+        .map(role => {
+          const id = firstAvailable(role, ['rol_id', 'id']);
+          const name = role.nombre ?? role.name ?? `Rol ${id}`;
+          return `<option value="${id}">${name}</option>`;
+        })
+        .join('');
+    if (currentValue) {
+      select.value = currentValue;
+    }
+  };
+
+  buildOptions(userRoleSelect);
+  buildOptions(rpRolSelect);
+}
+
+function renderPermissions() {
+  const tbody = settingsWrapper?.querySelector('[data-permissions-body]');
+  const rpPermisoSelect = document.getElementById('rpPermiso');
+
+  if (tbody) {
+    if (!state.permissions.length) {
+      tbody.innerHTML = '<tr><td colspan="4" class="settings-empty">Aún no has definido permisos.</td></tr>';
+    } else {
+      tbody.innerHTML = state.permissions
+        .map(permission => {
+          const id = firstAvailable(permission, ['permiso_id', 'id']);
+          const codigo = firstAvailable(permission, ['codigo', 'code']);
+          const categoria = firstAvailable(permission, ['categoria', 'category']);
+          const descripcion = firstAvailable(permission, ['descripcion', 'description']);
+          return `
+            <tr data-id="${id ?? ''}">
+              <td>${codigo ?? '—'}</td>
+              <td>${categoria ?? '—'}</td>
+              <td>${descripcion ?? '—'}</td>
+              <td class="text-right">
+                <button class="btn btn-link btn-sm" data-action="edit" data-id="${id}">Editar</button>
+                <button class="btn btn-link btn-sm text-danger" data-action="delete" data-id="${id}">Eliminar</button>
+              </td>
+            </tr>
+          `;
+        })
+        .join('');
+    }
+  }
+
+  if (rpPermisoSelect) {
+    const currentValue = rpPermisoSelect.value;
+    rpPermisoSelect.innerHTML = '<option value="">Selecciona permiso</option>' +
+      state.permissions
+        .map(permission => {
+          const id = firstAvailable(permission, ['permiso_id', 'id']);
+          const code = firstAvailable(permission, ['codigo', 'code', 'nombre']) ?? `Permiso ${id}`;
+          return `<option value="${id}">${code}</option>`;
+        })
+        .join('');
+    if (currentValue) {
+      rpPermisoSelect.value = currentValue;
+    }
+  }
+}
+
+function renderRolePermissions() {
+  const container = document.getElementById('rolePermissionList');
+  if (!container) return;
+
+  if (!state.rolePermissions.length) {
+    container.innerHTML = '<p class="settings-empty mb-0">Aún no hay permisos asociados a roles.</p>';
+    return;
+  }
+
+  const grouped = new Map();
+  for (const link of state.rolePermissions) {
+    const roleId = firstAvailable(link, ['rol_id', 'role_id']);
+    const permId = firstAvailable(link, ['permiso_id', 'permission_id']);
+    if (!roleId || !permId) continue;
+
+    const role = state.roles.find(r => firstAvailable(r, ['rol_id', 'id']) === roleId);
+    const permission = state.permissions.find(p => firstAvailable(p, ['permiso_id', 'id']) === permId);
+    const roleName = role?.nombre ?? role?.name ?? `Rol ${roleId}`;
+    const permName = firstAvailable(permission, ['codigo', 'code', 'nombre', 'name']) ?? `Permiso ${permId}`;
+
+    if (!grouped.has(roleId)) {
+      grouped.set(roleId, {
+        name: roleName,
+        permissions: []
+      });
+    }
+
+    grouped.get(roleId).permissions.push({
+      id: permId,
+      name: permName
+    });
+  }
+
+  const sections = Array.from(grouped.entries()).map(([roleId, info]) => {
+    const chips = info.permissions
+      .map(perm => `
+        <span class="settings-chip" data-role="${roleId}" data-permission="${perm.id}">
+          ${perm.name}
+          <button type="button" title="Quitar" data-action="remove-rp" data-role="${roleId}" data-permission="${perm.id}">×</button>
+        </span>
+      `)
+      .join('');
+
+    return `
+      <div class="mb-2" data-role="${roleId}">
+        <strong>${info.name}</strong>
+        <div class="mt-1">${chips || '<span class="text-muted">Sin permisos asignados.</span>'}</div>
+      </div>
+    `;
+  });
+
+  container.innerHTML = sections.join('');
+}
+
+function renderAudit() {
+  const tbody = settingsWrapper?.querySelector('[data-audit-body]');
+  if (!tbody) return;
+
+  if (!state.audit.length) {
+    tbody.innerHTML = '<tr><td colspan="5" class="settings-empty">No hay registros de auditoría para los filtros actuales.</td></tr>';
+    return;
+  }
+
+  tbody.innerHTML = state.audit
+    .map(entry => {
+      const fecha = firstAvailable(entry, ['fecha', 'created_at', 'fecha_evento', 'timestamp']);
+      const entidad = firstAvailable(entry, ['entidad', 'tabla', 'entity']);
+      const accion = firstAvailable(entry, ['accion', 'accion_realizada', 'action']);
+      const detalle = firstAvailable(entry, ['detalle', 'descripcion', 'description']);
+      const usuario = firstAvailable(entry, ['usuario', 'usuario_id', 'user_email', 'usuario_email']);
+
+      return `
+        <tr>
+          <td>${fecha ? formatDateTime(fecha) : '—'}</td>
+          <td>${entidad ?? '—'}</td>
+          <td>${accion ?? '—'}</td>
+          <td>${detalle ?? '—'}</td>
+          <td>${usuario ?? '—'}</td>
+        </tr>
+      `;
+    })
+    .join('');
+}
+
+function applyAuditFilters(data) {
+  const entidadFilter = normalizeString(state.auditFilters.entidad).toLowerCase();
+  const usuarioFilter = normalizeString(state.auditFilters.usuario).toLowerCase();
+
+  if (!entidadFilter && !usuarioFilter) return data;
+
+  return data.filter(entry => {
+    const entidad = normalizeString(firstAvailable(entry, ['entidad', 'tabla', 'entity'])).toLowerCase();
+    const usuario = normalizeString(firstAvailable(entry, ['usuario', 'usuario_id', 'user_email', 'usuario_email'])).toLowerCase();
+
+    const matchesEntidad = entidadFilter ? entidad.includes(entidadFilter) : true;
+    const matchesUsuario = usuarioFilter ? usuario.includes(usuarioFilter) : true;
+
+    return matchesEntidad && matchesUsuario;
+  });
+}
+
+function sortAudit(data) {
+  return [...data].sort((a, b) => {
+    const dateA = Date.parse(firstAvailable(a, ['fecha', 'created_at', 'fecha_evento', 'timestamp'])) || 0;
+    const dateB = Date.parse(firstAvailable(b, ['fecha', 'created_at', 'fecha_evento', 'timestamp'])) || 0;
+    return dateB - dateA;
+  });
+}
+
+function attachTableActions() {
+  const usersTbody = settingsWrapper?.querySelector('[data-users-body]');
+  const rolesTbody = settingsWrapper?.querySelector('[data-roles-body]');
+  const permissionsTbody = settingsWrapper?.querySelector('[data-permissions-body]');
+  const rpContainer = document.getElementById('rolePermissionList');
+
+  usersTbody?.addEventListener('click', async (event) => {
+    const button = event.target.closest('button[data-action]');
+    if (!button || !client) return;
+    const id = Number(button.dataset.id);
+    if (!id) return;
+
+    if (button.dataset.action === 'edit') {
+      const user = state.users.find(item => Number(firstAvailable(item, ['usuario_id', 'id'])) === id);
+      if (!user) return;
+      const form = document.getElementById('userForm');
+      if (!form) return;
+      form.usuario_id.value = id;
+      form.nombre.value = user.nombre ?? user.name ?? '';
+      form.email.value = user.email ?? '';
+      form.telefono.value = firstAvailable(user, ['telefono', 'phone']) ?? '';
+      form.rol_id.value = firstAvailable(user, ['rol_id', 'role_id']) ?? '';
+      form.estado.value = normalizeString(firstAvailable(user, ['estado', 'status', 'activo'])) || 'activo';
+      form.password.value = '';
+      showStatus('Editando usuario seleccionado. Guarda para aplicar cambios.', 'info', 3200);
+    } else if (button.dataset.action === 'delete') {
+      if (!window.confirm('¿Eliminar este usuario? Esta acción no se puede deshacer.')) return;
+      try {
+        const { error } = await client.from('usuario').delete().eq('usuario_id', id);
+        if (error) throw error;
+        showStatus('Usuario eliminado correctamente.');
+        await loadUsers();
+      } catch (error) {
+        console.error('[settings] Error al eliminar usuario', error);
+        showStatus(`No se pudo eliminar el usuario: ${error.message}`, 'error', 6500);
+      }
+    }
+  });
+
+  rolesTbody?.addEventListener('click', async (event) => {
+    const button = event.target.closest('button[data-action]');
+    if (!button || !client) return;
+    const id = Number(button.dataset.id);
+    if (!id) return;
+
+    if (button.dataset.action === 'edit') {
+      const role = state.roles.find(item => Number(firstAvailable(item, ['rol_id', 'id'])) === id);
+      if (!role) return;
+      const form = document.getElementById('roleForm');
+      if (!form) return;
+      form.rol_id.value = id;
+      form.nombre.value = role.nombre ?? role.name ?? '';
+      form.nivel.value = firstAvailable(role, ['nivel', 'priority']) ?? '';
+      form.descripcion.value = firstAvailable(role, ['descripcion', 'description']) ?? '';
+      showStatus('Editando rol seleccionado.', 'info', 3200);
+    } else if (button.dataset.action === 'delete') {
+      if (!window.confirm('¿Eliminar este rol? También se eliminarán sus asignaciones.')) return;
+      try {
+        const { error: relError } = await client.from('rol_permiso').delete().eq('rol_id', id);
+        if (relError) throw relError;
+        const usersWithRole = state.users.some(user => Number(firstAvailable(user, ['rol_id', 'role_id'])) === id);
+        if (usersWithRole) {
+          const { error: usersError } = await client.from('usuario').update({ rol_id: null }).eq('rol_id', id);
+          if (usersError) {
+            console.warn('[settings] No se pudo limpiar rol en usuarios', usersError);
+          }
+        }
+        const { error } = await client.from('rol').delete().eq('rol_id', id);
+        if (error) throw error;
+        showStatus('Rol eliminado correctamente.');
+        await Promise.all([loadRoles(), loadRolePermissions(), loadUsers()]);
+      } catch (error) {
+        console.error('[settings] Error al eliminar rol', error);
+        showStatus(`No se pudo eliminar el rol: ${error.message}`, 'error', 6500);
+      }
+    }
+  });
+
+  permissionsTbody?.addEventListener('click', async (event) => {
+    const button = event.target.closest('button[data-action]');
+    if (!button || !client) return;
+    const id = Number(button.dataset.id);
+    if (!id) return;
+
+    if (button.dataset.action === 'edit') {
+      const permission = state.permissions.find(item => Number(firstAvailable(item, ['permiso_id', 'id'])) === id);
+      if (!permission) return;
+      const form = document.getElementById('permissionForm');
+      if (!form) return;
+      form.permiso_id.value = id;
+      form.codigo.value = firstAvailable(permission, ['codigo', 'code', 'nombre']) ?? '';
+      form.categoria.value = firstAvailable(permission, ['categoria', 'category']) ?? '';
+      form.descripcion.value = firstAvailable(permission, ['descripcion', 'description']) ?? '';
+      showStatus('Editando permiso seleccionado.', 'info', 3200);
+    } else if (button.dataset.action === 'delete') {
+      if (!window.confirm('¿Eliminar este permiso? Se quitará de todos los roles.')) return;
+      try {
+        const { error: relError } = await client.from('rol_permiso').delete().eq('permiso_id', id);
+        if (relError) throw relError;
+        const { error } = await client.from('permiso').delete().eq('permiso_id', id);
+        if (error) throw error;
+        showStatus('Permiso eliminado correctamente.');
+        await Promise.all([loadPermissions(), loadRolePermissions()]);
+      } catch (error) {
+        console.error('[settings] Error al eliminar permiso', error);
+        showStatus(`No se pudo eliminar el permiso: ${error.message}`, 'error', 6500);
+      }
+    }
+  });
+
+  rpContainer?.addEventListener('click', async (event) => {
+    const button = event.target.closest('button[data-action="remove-rp"]');
+    if (!button || !client) return;
+    const rolId = Number(button.dataset.role);
+    const permisoId = Number(button.dataset.permission);
+    if (!rolId || !permisoId) return;
+
+    try {
+      const { error } = await client.from('rol_permiso').delete().match({ rol_id: rolId, permiso_id: permisoId });
+      if (error) throw error;
+      showStatus('Permiso retirado del rol.');
+      await loadRolePermissions();
+    } catch (error) {
+      console.error('[settings] Error al quitar permiso del rol', error);
+      showStatus(`No se pudo quitar el permiso: ${error.message}`, 'error', 6500);
+    }
+  });
+}
+
+async function loadUsers() {
+  if (!client) return;
+  try {
+    const { data, error } = await client.from('usuario').select('*');
+    if (error) throw error;
+    state.users = Array.isArray(data) ? data : [];
+    renderUsers();
+  } catch (error) {
+    console.error('[settings] Error al cargar usuarios', error);
+    showStatus(`Error al cargar usuarios: ${error.message}`, 'error', 6500);
+  }
+}
+
+async function loadRoles() {
+  if (!client) return;
+  try {
+    const { data, error } = await client.from('rol').select('*');
+    if (error) throw error;
+    state.roles = Array.isArray(data) ? data : [];
+    renderRoles();
+  } catch (error) {
+    console.error('[settings] Error al cargar roles', error);
+    showStatus(`Error al cargar roles: ${error.message}`, 'error', 6500);
+  }
+}
+
+async function loadPermissions() {
+  if (!client) return;
+  try {
+    const { data, error } = await client.from('permiso').select('*');
+    if (error) throw error;
+    state.permissions = Array.isArray(data) ? data : [];
+    renderPermissions();
+  } catch (error) {
+    console.error('[settings] Error al cargar permisos', error);
+    showStatus(`Error al cargar permisos: ${error.message}`, 'error', 6500);
+  }
+}
+
+async function loadRolePermissions() {
+  if (!client) return;
+  try {
+    const { data, error } = await client.from('rol_permiso').select('*');
+    if (error) throw error;
+    state.rolePermissions = Array.isArray(data) ? data : [];
+    renderRolePermissions();
+  } catch (error) {
+    console.error('[settings] Error al cargar asignaciones', error);
+    showStatus(`Error al cargar asignaciones: ${error.message}`, 'error', 6500);
+  }
+}
+
+async function loadAudit() {
+  if (!client) return;
+  try {
+    const { data, error } = await client.from('auditoria').select('*').limit(200);
+    if (error) throw error;
+    const sorted = sortAudit(Array.isArray(data) ? data : []);
+    state.auditRaw = sorted;
+    state.audit = applyAuditFilters(sorted);
+    renderAudit();
+  } catch (error) {
+    console.error('[settings] Error al cargar auditoría', error);
+    showStatus(`Error al cargar auditoría: ${error.message}`, 'error', 6500);
+  }
+}
+
+async function saveUser(event) {
+  event.preventDefault();
+  if (!client) return;
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const id = Number(formData.get('usuario_id')) || null;
+
+  const payload = {
+    nombre: nullableValue(formData.get('nombre')),
+    email: nullableValue(formData.get('email')),
+    telefono: nullableValue(formData.get('telefono')),
+    rol_id: Number(formData.get('rol_id')) || null,
+    estado: nullableValue(formData.get('estado')) || 'activo'
+  };
+
+  if (!payload.nombre || !payload.email) {
+    showStatus('Completa nombre y correo electrónico.', 'error', 5000);
+    return;
+  }
+
+  payload.email = payload.email.toLowerCase();
+
+  const password = normalizeString(formData.get('password'));
+  if (!id && !password) {
+    showStatus('Ingresa una contraseña temporal para nuevos usuarios.', 'error', 5000);
+    return;
+  }
+
+  if (password) {
+    payload.password_hash = await hashPassword(password);
+  }
+
+  try {
+    if (id) {
+      const { error } = await client.from('usuario').update(payload).eq('usuario_id', id);
+      if (error) throw error;
+      showStatus('Usuario actualizado correctamente.');
+    } else {
+      const { error } = await client.from('usuario').insert(payload);
+      if (error) throw error;
+      showStatus('Usuario creado correctamente.');
+    }
+    resetForm(form);
+    await loadUsers();
+  } catch (error) {
+    console.error('[settings] Error al guardar usuario', error);
+    showStatus(`No se pudo guardar el usuario: ${error.message}`, 'error', 6500);
+  }
+}
+
+async function saveRole(event) {
+  event.preventDefault();
+  if (!client) return;
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const id = Number(formData.get('rol_id')) || null;
+
+  const payload = {
+    nombre: nullableValue(formData.get('nombre')),
+    nivel: formData.get('nivel') ? Number(formData.get('nivel')) : null,
+    descripcion: nullableValue(formData.get('descripcion'))
+  };
+
+  if (!payload.nombre) {
+    showStatus('El nombre del rol es obligatorio.', 'error', 5000);
+    return;
+  }
+
+  try {
+    if (id) {
+      const { error } = await client.from('rol').update(payload).eq('rol_id', id);
+      if (error) throw error;
+      showStatus('Rol actualizado correctamente.');
+    } else {
+      const { error } = await client.from('rol').insert(payload);
+      if (error) throw error;
+      showStatus('Rol creado correctamente.');
+    }
+    resetForm(form);
+    await loadRoles();
+  } catch (error) {
+    console.error('[settings] Error al guardar rol', error);
+    showStatus(`No se pudo guardar el rol: ${error.message}`, 'error', 6500);
+  }
+}
+
+async function savePermission(event) {
+  event.preventDefault();
+  if (!client) return;
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const id = Number(formData.get('permiso_id')) || null;
+
+  const payload = {
+    codigo: nullableValue(formData.get('codigo')),
+    categoria: nullableValue(formData.get('categoria')),
+    descripcion: nullableValue(formData.get('descripcion'))
+  };
+
+  if (!payload.codigo) {
+    showStatus('El código del permiso es obligatorio.', 'error', 5000);
+    return;
+  }
+
+  try {
+    if (id) {
+      const { error } = await client.from('permiso').update(payload).eq('permiso_id', id);
+      if (error) throw error;
+      showStatus('Permiso actualizado correctamente.');
+    } else {
+      const { error } = await client.from('permiso').insert(payload);
+      if (error) throw error;
+      showStatus('Permiso creado correctamente.');
+    }
+    resetForm(form);
+    await loadPermissions();
+  } catch (error) {
+    console.error('[settings] Error al guardar permiso', error);
+    showStatus(`No se pudo guardar el permiso: ${error.message}`, 'error', 6500);
+  }
+}
+
+async function saveRolePermission(event) {
+  event.preventDefault();
+  if (!client) return;
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const rolId = Number(formData.get('rol_id'));
+  const permisoId = Number(formData.get('permiso_id'));
+  if (!rolId || !permisoId) {
+    showStatus('Selecciona un rol y un permiso para continuar.', 'error', 4000);
+    return;
+  }
+
+  const exists = state.rolePermissions.some(link => {
+    const rId = Number(firstAvailable(link, ['rol_id', 'role_id']));
+    const pId = Number(firstAvailable(link, ['permiso_id', 'permission_id']));
+    return rId === rolId && pId === permisoId;
+  });
+
+  if (exists) {
+    showStatus('Ese permiso ya está asignado al rol.', 'info', 3200);
+    return;
+  }
+
+  try {
+    const { error } = await client.from('rol_permiso').insert({ rol_id: rolId, permiso_id: permisoId });
+    if (error) throw error;
+    showStatus('Permiso asignado correctamente.');
+    resetForm(form);
+    await loadRolePermissions();
+  } catch (error) {
+    console.error('[settings] Error al asignar permiso', error);
+    showStatus(`No se pudo asignar el permiso: ${error.message}`, 'error', 6500);
+  }
+}
+
+function handleAuditFilter(event) {
+  event.preventDefault();
+  const form = event.currentTarget;
+  state.auditFilters.entidad = normalizeString(form.entidad?.value);
+  state.auditFilters.usuario = normalizeString(form.usuario?.value);
+  state.audit = applyAuditFilters(sortAudit(state.auditRaw));
+  renderAudit();
+}
+
+function resetForm(form) {
+  if (!form) return;
+  form.reset();
+  const hiddenInputs = form.querySelectorAll('input[type="hidden"]');
+  hiddenInputs.forEach(input => {
+    input.value = '';
+  });
+  if (form.id === 'userForm') {
+    const estadoField = form.querySelector('[name="estado"]');
+    if (estadoField) {
+      estadoField.value = 'activo';
+    }
+  }
+}
+
+async function initialize() {
+  if (!settingsWrapper) return;
+
+  const config = window.APP_CONFIG || {};
+  if (!window.supabase || !config.supabaseUrl || !config.supabaseAnonKey) {
+    setPlaceholderVisible(true);
+    showStatus('Configura tu URL y anon key de Supabase en Js/config.js para activar este módulo.', 'error', 0);
+    return;
+  }
+
+  client = window.supabase.createClient(config.supabaseUrl, config.supabaseAnonKey, {
+    auth: {
+      persistSession: false
+    }
+  });
+
+  setPlaceholderVisible(false);
+  settingsWrapper.hidden = false;
+
+  attachTableActions();
+
+  document.getElementById('userForm')?.addEventListener('submit', saveUser);
+  document.getElementById('roleForm')?.addEventListener('submit', saveRole);
+  document.getElementById('permissionForm')?.addEventListener('submit', savePermission);
+  document.getElementById('rolePermissionForm')?.addEventListener('submit', saveRolePermission);
+  document.getElementById('auditFilterForm')?.addEventListener('submit', handleAuditFilter);
+
+  document.getElementById('userReset')?.addEventListener('click', () => {
+    resetForm(document.getElementById('userForm'));
+    hideStatus();
+  });
+  document.getElementById('roleReset')?.addEventListener('click', () => {
+    resetForm(document.getElementById('roleForm'));
+    hideStatus();
+  });
+  document.getElementById('permissionReset')?.addEventListener('click', () => {
+    resetForm(document.getElementById('permissionForm'));
+    hideStatus();
+  });
+  document.getElementById('auditReset')?.addEventListener('click', async () => {
+    resetForm(document.getElementById('auditFilterForm'));
+    state.auditFilters = { entidad: '', usuario: '' };
+    await loadAudit();
+  });
+
+  await Promise.all([loadRoles(), loadPermissions()]);
+  await Promise.all([loadUsers(), loadRolePermissions(), loadAudit()]);
+  showStatus('Panel de configuración conectado correctamente.', 'info', 3200);
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initialize);
+} else {
+  initialize();
+}

--- a/admin.html
+++ b/admin.html
@@ -255,6 +255,13 @@
       border: 1px solid rgba(255, 255, 255, 0.4);
     }
 
+    .section-subtitle {
+      font-size: 1.05rem;
+      font-weight: 600;
+      color: #1e3c72;
+      margin-bottom: 18px;
+    }
+
     .section-title {
       font-size: 1.5rem;
       font-weight: 600;
@@ -263,6 +270,76 @@
       display: flex;
       align-items: center;
       gap: 12px;
+    }
+
+    .info-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+
+    .info-card,
+    .data-card {
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.8));
+      border-radius: 20px;
+      padding: 20px;
+      box-shadow: 0 15px 30px rgba(30, 60, 114, 0.14);
+    }
+
+    .info-card h3 {
+      font-size: 0.95rem;
+      font-weight: 600;
+      margin-bottom: 6px;
+      color: #274b93;
+    }
+
+    .info-card strong {
+      font-size: 1.35rem;
+      color: #0f274f;
+    }
+
+    .info-card span {
+      font-size: 0.85rem;
+      color: #546b9b;
+    }
+
+    .data-grid {
+      display: grid;
+      gap: 20px;
+    }
+
+    .data-grid.two-columns {
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+
+    .data-card h4 {
+      font-size: 1.05rem;
+      font-weight: 600;
+      margin-bottom: 14px;
+      color: #274b93;
+    }
+
+    .data-card p {
+      margin-bottom: 14px;
+      font-size: 0.9rem;
+      color: #4c5f86;
+    }
+
+    .data-card table {
+      margin-bottom: 0;
+    }
+
+    .data-card .table thead th {
+      border-top: none;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+    }
+
+    .data-card .table tbody td {
+      font-size: 0.9rem;
+      vertical-align: middle;
     }
 
     .badge-pill {
@@ -301,6 +378,129 @@
       font-size: 0.9rem;
       line-height: 1.4;
       margin: 0;
+    }
+
+    .settings-wrapper {
+      margin-top: 24px;
+    }
+
+    .settings-status {
+      border-radius: 14px;
+      padding: 14px 18px;
+      margin-bottom: 16px;
+      background: rgba(42, 82, 152, 0.12);
+      color: #1e3c72;
+      font-weight: 500;
+      display: none;
+    }
+
+    .settings-status.error {
+      background: rgba(220, 53, 69, 0.12);
+      color: #b02a37;
+    }
+
+    .settings-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: 22px;
+    }
+
+    .settings-panel {
+      background: rgba(255, 255, 255, 0.9);
+      border-radius: 20px;
+      padding: 22px 20px;
+      box-shadow: 0 16px 36px rgba(30, 60, 114, 0.18);
+      display: flex;
+      flex-direction: column;
+      min-height: 100%;
+    }
+
+    .settings-panel h3 {
+      font-size: 1.15rem;
+      font-weight: 600;
+      margin-bottom: 12px;
+      color: #1f2a40;
+    }
+
+    .settings-panel .panel-description {
+      font-size: 0.9rem;
+      color: #5c6c8c;
+      margin-bottom: 18px;
+    }
+
+    .settings-panel form {
+      background: rgba(242, 247, 255, 0.7);
+      border-radius: 16px;
+      padding: 14px 16px;
+      margin-bottom: 18px;
+    }
+
+    .settings-panel form .form-group:last-child {
+      margin-bottom: 0;
+    }
+
+    .settings-panel table {
+      width: 100%;
+      font-size: 0.87rem;
+      margin-bottom: 0;
+    }
+
+    .settings-panel table thead th {
+      border-top: none;
+      background: rgba(30, 60, 114, 0.05);
+    }
+
+    .settings-panel table tbody td {
+      vertical-align: middle;
+    }
+
+    .settings-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 10px;
+      border-radius: 999px;
+      background: rgba(30, 60, 114, 0.12);
+      color: #1e3c72;
+      font-size: 0.75rem;
+      margin: 4px 6px 4px 0;
+    }
+
+    .settings-chip button {
+      border: none;
+      background: transparent;
+      color: inherit;
+      padding: 0;
+      line-height: 1;
+      cursor: pointer;
+    }
+
+    .settings-inline {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 12px;
+    }
+
+    .settings-empty {
+      font-size: 0.9rem;
+      color: #6c7a92;
+      text-align: center;
+      padding: 18px 0;
+    }
+
+    .settings-subsection {
+      margin-bottom: 20px;
+    }
+
+    .settings-subsection:last-child {
+      margin-bottom: 0;
+    }
+
+    .settings-subsection h4 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-bottom: 10px;
+      color: #1e3c72;
     }
 
     /* Dropzone adjustments */
@@ -445,6 +645,85 @@
           <div class="section-card">
             <h2 class="section-title">Panel financiero unificado <span class="badge badge-pill badge-primary">Automático</span></h2>
             <iframe src="dashboard-financiero.html" class="dashboard-frame" loading="lazy" title="Dashboard Financiero"></iframe>
+            <div class="mt-4">
+              <h3 class="section-subtitle">Indicadores clave de Joyeria Mares</h3>
+              <div class="info-grid" id="dashboardKpiGrid"></div>
+            </div>
+
+            <div class="data-grid two-columns">
+              <article class="data-card">
+                <h4>Estructura de roles</h4>
+                <p>Resumen de los perfiles operativos y permisos configurados en la base de datos Joyeria.</p>
+                <table class="table table-sm table-hover" id="dashboardRolesTable">
+                  <thead class="thead-light">
+                    <tr>
+                      <th>Rol</th>
+                      <th>Permisos asignados</th>
+                    </tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </article>
+
+              <article class="data-card">
+                <h4>Catálogo de permisos</h4>
+                <p>Permisos disponibles para distribuir entre los equipos comerciales y de inventario.</p>
+                <table class="table table-sm table-striped" id="dashboardPermisosTable">
+                  <thead class="thead-light">
+                    <tr>
+                      <th>Permiso</th>
+                      <th>Descripción</th>
+                    </tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </article>
+            </div>
+
+            <div class="data-grid two-columns mt-4">
+              <article class="data-card">
+                <h4>Usuarios activos</h4>
+                <p>Listado de los administradores y colaboradores habilitados para operar el sistema.</p>
+                <table class="table table-sm table-hover" id="dashboardUsuariosTable">
+                  <thead class="thead-light">
+                    <tr>
+                      <th>Nombre</th>
+                      <th>Correo</th>
+                      <th>Rol</th>
+                      <th>Estado</th>
+                    </tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </article>
+
+              <article class="data-card">
+                <h4>Monitoreo de actividad</h4>
+                <p>Últimos eventos registrados en bitácoras y auditoría para seguimiento ejecutivo.</p>
+                <div class="table-responsive mb-3">
+                  <table class="table table-sm table-striped" id="dashboardBitacoraTable">
+                    <thead class="thead-light">
+                      <tr>
+                        <th>Usuario</th>
+                        <th>Acción</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+                <div class="table-responsive">
+                  <table class="table table-sm table-hover" id="dashboardAuditoriaTable">
+                    <thead class="thead-light">
+                      <tr>
+                        <th>Usuario</th>
+                        <th>Descripción</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+              </article>
+            </div>
           </div>
         </section>
 
@@ -471,6 +750,75 @@
                 <tbody></tbody>
               </table>
             </div>
+            <div class="mt-4">
+              <h3 class="section-subtitle">Catálogo Joyeria Mares</h3>
+              <div class="info-grid" id="productSummaryCards"></div>
+            </div>
+
+            <div class="data-grid two-columns">
+              <article class="data-card">
+                <h4>Productos destacados</h4>
+                <p>Inventario inicial con categorías, materiales y existencias actuales.</p>
+                <div class="table-responsive">
+                  <table class="table table-sm table-hover" id="datasetProductosTable">
+                    <thead class="thead-light">
+                      <tr>
+                        <th>Producto</th>
+                        <th>Categoría</th>
+                        <th>Material</th>
+                        <th>Precio (GTQ)</th>
+                        <th>Stock</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+              </article>
+
+              <article class="data-card">
+                <h4>Clasificaciones</h4>
+                <p>Catálogo base de categorías y materiales disponibles para nuevos lanzamientos.</p>
+                <div class="table-responsive mb-3">
+                  <table class="table table-sm table-striped" id="datasetCategoriasTable">
+                    <thead class="thead-light">
+                      <tr>
+                        <th>Categoría</th>
+                        <th>Productos</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+                <div class="table-responsive">
+                  <table class="table table-sm table-striped" id="datasetMaterialesTable">
+                    <thead class="thead-light">
+                      <tr>
+                        <th>Material</th>
+                        <th>Uso principal</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+              </article>
+            </div>
+
+            <div class="data-card mt-4">
+              <h4>Movimientos de inventario</h4>
+              <p>Entradas y salidas registradas por el equipo de almacén.</p>
+              <div class="table-responsive">
+                <table class="table table-sm table-hover" id="datasetMovimientosTable">
+                  <thead class="thead-light">
+                    <tr>
+                      <th>Producto</th>
+                      <th>Tipo</th>
+                      <th>Cantidad</th>
+                    </tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </div>
+            </div>
           </div>
         </section>
 
@@ -486,45 +834,486 @@
       loading="lazy"
       title="Dashboard de reportería"
     ></iframe>
+    <div class="mt-4">
+      <h3 class="section-subtitle">CRM y pipeline comercial</h3>
+      <div class="info-grid" id="salesSummaryCards"></div>
+    </div>
+    <div class="data-grid two-columns">
+      <article class="data-card">
+        <h4>Clientes destacados</h4>
+        <p>Contactos con historial de compras y canales de comunicación registrados.</p>
+        <div class="table-responsive mb-3">
+          <table class="table table-sm table-hover" id="salesClientesTable">
+            <thead class="thead-light">
+              <tr>
+                <th>Cliente</th>
+                <th>Correo</th>
+                <th>Teléfono</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+        <div class="table-responsive">
+          <table class="table table-sm table-striped" id="salesEventosTable">
+            <thead class="thead-light">
+              <tr>
+                <th>Evento</th>
+                <th>Fecha</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </article>
+
+      <article class="data-card">
+        <h4>Notificaciones y asistencia</h4>
+        <p>Campañas enviadas y conversaciones atendidas por el chatbot.</p>
+        <div class="table-responsive mb-3">
+          <table class="table table-sm table-striped" id="salesNotificacionesTable">
+            <thead class="thead-light">
+              <tr>
+                <th>Notificación</th>
+                <th>Audiencia</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+        <div class="table-responsive">
+          <table class="table table-sm table-hover" id="salesChatbotTable">
+            <thead class="thead-light">
+              <tr>
+                <th>Cliente</th>
+                <th>Consulta</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </article>
+    </div>
+
+    <div class="data-card mt-4">
+      <h4>Órdenes y devoluciones</h4>
+      <p>Detalle de los carritos convertidos y seguimiento de entregas.</p>
+      <div class="table-responsive mb-3">
+        <table class="table table-sm table-hover" id="salesOrdenesTable">
+          <thead class="thead-light">
+            <tr>
+              <th>Orden</th>
+              <th>Cliente</th>
+              <th>Estado</th>
+              <th>Total (GTQ)</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <div class="table-responsive mb-3">
+        <table class="table table-sm table-striped" id="salesDetalleTable">
+          <thead class="thead-light">
+            <tr>
+              <th>Orden</th>
+              <th>Producto</th>
+              <th>Cantidad</th>
+              <th>Precio (GTQ)</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <div class="table-responsive">
+        <table class="table table-sm table-striped" id="salesDevolucionesTable">
+          <thead class="thead-light">
+            <tr>
+              <th>Orden</th>
+              <th>Motivo</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </section>
 
 
         <section class="content-section" id="section-revenue">
           <div class="section-card">
-            <h2 class="section-title">Administración de ingresos</h2>
-            <div class="placeholder-panel">
-              <div class="placeholder-card">
-                <h4>Seguimiento financiero</h4>
-                <p>Visualiza tus ingresos por línea de negocio, calcula márgenes y controla tus costos en un solo panel.</p>
-              </div>
-              <div class="placeholder-card">
-                <h4>Conciliación rápida</h4>
-                <p>Consolida tus facturas emitidas y pendientes de cobro. Integra herramientas contables cuando lo requieras.</p>
-              </div>
-              <div class="placeholder-card">
-                <h4>Objetivos trimestrales</h4>
-                <p>Planifica tus metas financieras y haz seguimiento del progreso con indicadores personalizados.</p>
-              </div>
+            <div class="d-flex flex-wrap align-items-center mb-3">
+              <h2 class="section-title mb-0">Administración de ingresos</h2>
+              <span class="badge badge-pill badge-warning ml-2">Finanzas</span>
+            </div>
+            <div class="info-grid" id="revenueSummaryCards"></div>
+
+            <div class="data-grid two-columns">
+              <article class="data-card">
+                <h4>Pagos recibidos</h4>
+                <p>Detalle de transacciones por orden, método de pago y estado.</p>
+                <div class="table-responsive mb-3">
+                  <table class="table table-sm table-hover" id="revenuePagosTable">
+                    <thead class="thead-light">
+                      <tr>
+                        <th>Orden</th>
+                        <th>Monto (GTQ)</th>
+                        <th>Estado</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+                <div class="table-responsive">
+                  <table class="table table-sm table-striped" id="revenueOrdenMetodoTable">
+                    <thead class="thead-light">
+                      <tr>
+                        <th>Orden</th>
+                        <th>Método</th>
+                        <th>Monto (GTQ)</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+              </article>
+
+              <article class="data-card">
+                <h4>Comprobantes y métodos</h4>
+                <p>Documentación de respaldo para conciliación contable.</p>
+                <div class="table-responsive mb-3">
+                  <table class="table table-sm table-hover" id="revenueMetodosTable">
+                    <thead class="thead-light">
+                      <tr>
+                        <th>Método</th>
+                        <th>Disponibilidad</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+                <div class="table-responsive">
+                  <table class="table table-sm table-striped" id="revenueComprobantesTable">
+                    <thead class="thead-light">
+                      <tr>
+                        <th>Pago</th>
+                        <th>Archivo</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+              </article>
+            </div>
+
+            <div class="data-grid two-columns mt-4">
+              <article class="data-card">
+                <h4>Compras a proveedores</h4>
+                <p>Registro de órdenes de compra y condiciones pactadas.</p>
+                <div class="table-responsive mb-3">
+                  <table class="table table-sm table-hover" id="revenueComprasTable">
+                    <thead class="thead-light">
+                      <tr>
+                        <th>Compra</th>
+                        <th>Proveedor</th>
+                        <th>Total (GTQ)</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+                <div class="table-responsive">
+                  <table class="table table-sm table-striped" id="revenueCompraDetalleTable">
+                    <thead class="thead-light">
+                      <tr>
+                        <th>Compra</th>
+                        <th>Producto</th>
+                        <th>Cantidad</th>
+                        <th>Precio (GTQ)</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+              </article>
+
+              <article class="data-card">
+                <h4>Logística y entregas</h4>
+                <p>Seguimiento de envíos y transportistas asignados.</p>
+                <div class="table-responsive mb-3">
+                  <table class="table table-sm table-hover" id="revenueEnviosTable">
+                    <thead class="thead-light">
+                      <tr>
+                        <th>Orden</th>
+                        <th>Transportista</th>
+                        <th>Estado</th>
+                        <th>Tracking</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+                <div class="table-responsive">
+                  <table class="table table-sm table-striped" id="revenueEnvioDetalleTable">
+                    <thead class="thead-light">
+                      <tr>
+                        <th>Envío</th>
+                        <th>Producto</th>
+                        <th>Cantidad</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+              </article>
             </div>
           </div>
         </section>
 
         <section class="content-section" id="section-settings">
           <div class="section-card">
-            <h2 class="section-title">Configuración y seguridad</h2>
-            <div class="placeholder-panel">
-              <div class="placeholder-card">
-                <h4>Usuarios y roles</h4>
-                <p>Define accesos por perfil para proteger información sensible y delegar funciones operativas.</p>
+            <div class="d-flex flex-wrap align-items-center justify-content-between mb-3">
+              <div>
+                <h2 class="section-title mb-1">Configuración y seguridad</h2>
+                <p class="text-muted mb-0">Administra usuarios, roles, permisos y auditorías vinculados a tu instancia de Supabase.</p>
               </div>
-              <div class="placeholder-card">
-                <h4>Preferencias del panel</h4>
-                <p>Personaliza colores, notificaciones y accesos directos a los módulos más utilizados por tu equipo.</p>
-              </div>
-              <div class="placeholder-card">
-                <h4>Auditoría</h4>
-                <p>Monitorea cambios realizados en el sistema y mantén un historial completo de modificaciones.</p>
+              <span class="badge badge-pill badge-info">Supabase</span>
+            </div>
+
+            <div id="settingsStatus" class="settings-status" role="status"></div>
+            <div id="settingsPlaceholder" class="settings-empty">Copia <code>Js/config.sample.js</code> a <code>Js/config.js</code> y coloca tu <strong>SUPABASE_URL</strong> y <strong>anon key</strong> para activar este panel.</div>
+
+            <div class="settings-wrapper" id="settingsWrapper" hidden>
+              <div class="settings-grid">
+                <article class="settings-panel" id="settingsUsers">
+                  <h3>Usuarios y roles</h3>
+                  <p class="panel-description">Gestiona cuentas internas y asigna roles según las responsabilidades dentro del negocio.</p>
+
+                  <form id="userForm" autocomplete="off">
+                    <input type="hidden" name="usuario_id" />
+                    <div class="form-row">
+                      <div class="form-group col-md-6">
+                        <label for="userNombre">Nombre</label>
+                        <input id="userNombre" name="nombre" type="text" class="form-control" required />
+                      </div>
+                      <div class="form-group col-md-6">
+                        <label for="userEmail">Correo electrónico</label>
+                        <input id="userEmail" name="email" type="email" class="form-control" required />
+                      </div>
+                    </div>
+
+                    <div class="form-row">
+                      <div class="form-group col-md-4">
+                        <label for="userTelefono">Teléfono</label>
+                        <input id="userTelefono" name="telefono" type="text" class="form-control" placeholder="+502..." />
+                      </div>
+                      <div class="form-group col-md-4">
+                        <label for="userRol">Rol</label>
+                        <select id="userRol" name="rol_id" class="form-control" required>
+                          <option value="">Selecciona rol</option>
+                        </select>
+                      </div>
+                      <div class="form-group col-md-4">
+                        <label for="userEstado">Estado</label>
+                        <select id="userEstado" name="estado" class="form-control">
+                          <option value="activo">Activo</option>
+                          <option value="inactivo">Inactivo</option>
+                          <option value="suspendido">Suspendido</option>
+                        </select>
+                      </div>
+                    </div>
+
+                    <div class="form-row">
+                      <div class="form-group col-md-6">
+                        <label for="userPassword">Contraseña temporal</label>
+                        <input id="userPassword" name="password" type="password" class="form-control" placeholder="Opcional" autocomplete="new-password" />
+                        <small class="form-text text-muted">Se almacenará como hash SHA-256. Úsala para restablecer accesos puntuales.</small>
+                      </div>
+                      <div class="form-group col-md-6 align-self-end text-right">
+                        <button class="btn btn-primary btn-sm" type="submit">Guardar usuario</button>
+                        <button class="btn btn-link btn-sm text-danger" id="userReset" type="button">Cancelar</button>
+                      </div>
+                    </div>
+                  </form>
+
+                  <div class="table-responsive">
+                    <table class="table table-hover table-sm" id="settingsUsersTable">
+                      <thead>
+                        <tr>
+                          <th>Nombre</th>
+                          <th>Correo</th>
+                          <th>Rol</th>
+                          <th>Estado</th>
+                          <th>Último acceso</th>
+                          <th class="text-right">Acciones</th>
+                        </tr>
+                      </thead>
+                      <tbody data-users-body>
+                        <tr>
+                          <td colspan="6" class="settings-empty">Conecta Supabase para ver tus usuarios administrativos.</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </article>
+
+                <article class="settings-panel" id="settingsRoles">
+                  <h3>Roles y permisos</h3>
+                  <p class="panel-description">Crea roles personalizados, mantén tu catálogo de permisos y controla qué puede hacer cada perfil.</p>
+
+                  <div class="settings-subsection">
+                    <h4>Roles</h4>
+                    <form id="roleForm" autocomplete="off">
+                      <input type="hidden" name="rol_id" />
+                      <div class="form-row">
+                        <div class="form-group col-md-6">
+                          <label for="roleNombre">Nombre</label>
+                          <input id="roleNombre" name="nombre" type="text" class="form-control" required />
+                        </div>
+                        <div class="form-group col-md-6">
+                          <label for="roleNivel">Nivel</label>
+                          <input id="roleNivel" name="nivel" type="number" class="form-control" min="1" step="1" placeholder="1 = mayor prioridad" />
+                          <small class="form-text text-muted">El nivel ayuda a ordenar jerarquías. Valores bajos indican mayor privilegio.</small>
+                        </div>
+                      </div>
+                      <div class="form-group">
+                        <label for="roleDescripcion">Descripción</label>
+                        <textarea id="roleDescripcion" name="descripcion" class="form-control" rows="2" placeholder="Ej. Gestiona inventarios y catálogos."></textarea>
+                      </div>
+                      <div class="text-right">
+                        <button class="btn btn-primary btn-sm" type="submit">Guardar rol</button>
+                        <button class="btn btn-link btn-sm text-danger" id="roleReset" type="button">Cancelar</button>
+                      </div>
+                    </form>
+
+                    <div class="table-responsive">
+                      <table class="table table-sm table-hover" id="settingsRolesTable">
+                        <thead>
+                          <tr>
+                            <th>Rol</th>
+                            <th>Nivel</th>
+                            <th>Descripción</th>
+                            <th class="text-right">Acciones</th>
+                          </tr>
+                        </thead>
+                        <tbody data-roles-body>
+                          <tr>
+                            <td colspan="4" class="settings-empty">Sin roles cargados todavía.</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+
+                  <div class="settings-subsection">
+                    <h4>Permisos</h4>
+                    <form id="permissionForm" autocomplete="off">
+                      <input type="hidden" name="permiso_id" />
+                      <div class="form-row">
+                        <div class="form-group col-md-4">
+                          <label for="permisoCodigo">Código</label>
+                          <input id="permisoCodigo" name="codigo" type="text" class="form-control" placeholder="inventario.listar" required />
+                        </div>
+                        <div class="form-group col-md-4">
+                          <label for="permisoCategoria">Categoría</label>
+                          <input id="permisoCategoria" name="categoria" type="text" class="form-control" placeholder="Inventario" />
+                        </div>
+                        <div class="form-group col-md-4">
+                          <label for="permisoDescripcion">Descripción</label>
+                          <input id="permisoDescripcion" name="descripcion" type="text" class="form-control" placeholder="Acceso a listado de productos" />
+                        </div>
+                      </div>
+                      <div class="text-right">
+                        <button class="btn btn-primary btn-sm" type="submit">Guardar permiso</button>
+                        <button class="btn btn-link btn-sm text-danger" id="permissionReset" type="button">Cancelar</button>
+                      </div>
+                    </form>
+
+                    <div class="table-responsive">
+                      <table class="table table-sm table-hover" id="settingsPermissionsTable">
+                        <thead>
+                          <tr>
+                            <th>Código</th>
+                            <th>Categoría</th>
+                            <th>Descripción</th>
+                            <th class="text-right">Acciones</th>
+                          </tr>
+                        </thead>
+                        <tbody data-permissions-body>
+                          <tr>
+                            <td colspan="4" class="settings-empty">Registra tus primeros permisos para habilitar accesos avanzados.</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+
+                  <div class="settings-subsection">
+                    <h4>Asignación de permisos</h4>
+                    <form id="rolePermissionForm" class="settings-inline" autocomplete="off">
+                      <div class="form-group mb-0">
+                        <label for="rpRol">Rol</label>
+                        <select id="rpRol" name="rol_id" class="form-control" required>
+                          <option value="">Selecciona rol</option>
+                        </select>
+                      </div>
+                      <div class="form-group mb-0">
+                        <label for="rpPermiso">Permiso</label>
+                        <select id="rpPermiso" name="permiso_id" class="form-control" required>
+                          <option value="">Selecciona permiso</option>
+                        </select>
+                      </div>
+                      <div class="form-group mb-0 align-self-end text-right">
+                        <button class="btn btn-outline-primary btn-sm" type="submit">Asignar</button>
+                      </div>
+                    </form>
+
+                    <div id="rolePermissionList" class="mt-3">
+                      <p class="settings-empty mb-0">Aún no hay permisos asociados a roles.</p>
+                    </div>
+                  </div>
+                </article>
+
+                <article class="settings-panel" id="settingsAudit">
+                  <h3>Auditoría</h3>
+                  <p class="panel-description">Revisa el historial de acciones registradas en tu tabla <code>auditoria</code> para identificar cambios sensibles.</p>
+
+                  <div class="settings-subsection">
+                    <form id="auditFilterForm" class="settings-inline" autocomplete="off">
+                      <div class="form-group mb-0">
+                        <label for="auditEntidad">Entidad</label>
+                        <input id="auditEntidad" name="entidad" type="text" class="form-control" placeholder="Ej. usuario" />
+                      </div>
+                      <div class="form-group mb-0">
+                        <label for="auditUsuario">Usuario</label>
+                        <input id="auditUsuario" name="usuario" type="text" class="form-control" placeholder="ID o correo" />
+                      </div>
+                      <div class="form-group mb-0 align-self-end text-right">
+                        <button class="btn btn-outline-primary btn-sm" type="submit">Filtrar</button>
+                        <button class="btn btn-link btn-sm" id="auditReset" type="button">Limpiar</button>
+                      </div>
+                    </form>
+                  </div>
+
+                  <div class="table-responsive flex-grow-1">
+                    <table class="table table-sm table-striped mb-0" id="settingsAuditTable">
+                      <thead>
+                        <tr>
+                          <th>Fecha</th>
+                          <th>Entidad</th>
+                          <th>Acción</th>
+                          <th>Detalle</th>
+                          <th>Usuario</th>
+                        </tr>
+                      </thead>
+                      <tbody data-audit-body>
+                        <tr>
+                          <td colspan="5" class="settings-empty">Conecta Supabase para consultar los eventos de auditoría.</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </article>
               </div>
             </div>
           </div>
@@ -618,6 +1407,10 @@
 
   <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="Js/config.js"></script>
+  <script type="module" src="Js/admin-dashboard-data.js"></script>
+  <script type="module" src="Js/settings.js"></script>
   <script type="module" src="Js/admin.js"></script>
   <script>
     const layout = document.getElementById('adminLayout');


### PR DESCRIPTION
## Summary
- style the admin dashboard with reusable info cards and data-grid tables to surface Joyeria metrics across executive, productos, ventas e ingresos views
- add Joyeria-derived data summaries and tables to each dashboard section so the SQL sample is visible without manual queries
- create a dedicated `admin-dashboard-data.js` module that seeds the dashboard with the Joyeria dataset and renders the new visualizations

## Testing
- not run (static HTML updates)


------
https://chatgpt.com/codex/tasks/task_e_68dc978d7bc08325ab76c73c0b480ee3