### PR TITLE
Integrate reporteria dashboard with API data

### DIFF
--- a/reporteria.html
+++ b/reporteria.html
@@ -236,89 +236,485 @@
   </section>
 
   <script>
-    // ===== Datos (tomados del componente original) =====
-    const salesData = [
-      { month: 'Ene', ventas: 15600, ordenes: 24, clientes: 18 },
-      { month: 'Feb', ventas: 18200, ordenes: 28, clientes: 22 },
-      { month: 'Mar', ventas: 22400, ordenes: 35, clientes: 28 },
-      { month: 'Apr', ventas: 19800, ordenes: 31, clientes: 25 },
-      { month: 'May', ventas: 25600, ordenes: 41, clientes: 33 },
-      { month: 'Jun', ventas: 28900, ordenes: 45, clientes: 36 },
-      { month: 'Jul', ventas: 31200, ordenes: 48, clientes: 39 },
-      { month: 'Ago', ventas: 29500, ordenes: 46, clientes: 37 },
-      { month: 'Sep', ventas: 33800, ordenes: 52, clientes: 42 }
-    ];
+    const fmtCurrency = (n) => new Intl.NumberFormat('es-GT', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(Number.isFinite(n) ? n : 0);
+    const fmtNumber = (n) => new Intl.NumberFormat('es-GT').format(Number.isFinite(n) ? n : 0);
+    const monthFormatter = new Intl.DateTimeFormat('es-GT', { month: 'short' });
 
-    const productCategories = [
-      { name: 'Anillos', value: 35, ventas: 89400, color: '#8884d8' },
-      { name: 'Collares', value: 25, ventas: 64200, color: '#82ca9d' },
-      { name: 'Pulseras', value: 20, ventas: 51300, color: '#ffc658' },
-      { name: 'Aretes', value: 15, ventas: 38400, color: '#ff7300' },
-      { name: 'Relojes', value: 5, ventas: 12800, color: '#8dd1e1' }
-    ];
+    let salesData = [];
+    let productCategories = [];
+    let topClients = [];
+    let recentOrders = [];
+    let dashboardTotals = { sales: 0, orders: 0, clients: 0 };
 
-    const topClients = [
-      { nombre: 'María González', compras: 8, total: 4200, ultimaCompra: '2025-09-25' },
-      { nombre: 'Ana Rodríguez', compras: 6, total: 3800, ultimaCompra: '2025-09-23' },
-      { nombre: 'Carmen López', compras: 5, total: 3200, ultimaCompra: '2025-09-20' },
-      { nombre: 'Isabel Martín', compras: 4, total: 2900, ultimaCompra: '2025-09-18' },
-      { nombre: 'Laura Pérez', compras: 3, total: 2400, ultimaCompra: '2025-09-15' }
-    ];
+    let chartTrend, chartCategories, chartSalesBars, chartInventory;
 
-    const recentOrders = [
-      { id: '#ORD-001', cliente: 'María González', producto: 'Anillo Oro 18k', monto: 650, estado: 'Completado', fecha: '2025-09-26' },
-      { id: '#ORD-002', cliente: 'Carlos Ruiz', producto: 'Collar Plata 925', monto: 280, estado: 'Procesando', fecha: '2025-09-26' },
-      { id: '#ORD-003', cliente: 'Ana Rodríguez', producto: 'Pulsera Diamantes', monto: 1200, estado: 'Enviado', fecha: '2025-09-25' },
-      { id: '#ORD-004', cliente: 'Luis García', producto: 'Aretes Perlas', monto: 450, estado: 'Completado', fecha: '2025-09-25' },
-      { id: '#ORD-005', cliente: 'Carmen López', producto: 'Reloj Oro Rosa', monto: 890, estado: 'Completado', fecha: '2025-09-24' }
-    ];
+    const periodSelect = document.getElementById('periodSelect');
+    const refreshBtn = document.getElementById('btnRefresh');
+    const exportBtn = document.getElementById('btnExport');
 
-    // ===== Utilidades =====
-    const fmtCurrency = (n) => new Intl.NumberFormat('es-GT', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(n);
-    const fmtNumber = (n) => new Intl.NumberFormat('es-GT').format(n);
+    function toNumber(value) {
+      const num = Number(value);
+      return Number.isFinite(num) ? num : 0;
+    }
+
+    function capitalize(str) {
+      if (!str) return '';
+      return str.charAt(0).toUpperCase() + str.slice(1);
+    }
+
+    function formatMonthLabel(year, monthNumber) {
+      const date = new Date(year, monthNumber - 1, 1);
+      if (Number.isNaN(date.getTime())) return `${year}-${monthNumber}`;
+      return `${capitalize(monthFormatter.format(date))} ${String(year).slice(-2)}`;
+    }
+
+    function formatDateISO(date) {
+      if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
+      return date.toISOString().slice(0, 10);
+    }
+
+    function formatOrderDisplayId(id) {
+      if (id === null || id === undefined) return '#ORD';
+      const text = String(id).trim();
+      if (!text) return '#ORD';
+      if (text.startsWith('#')) return text;
+      if (/^ord/i.test(text)) return text.startsWith('#') ? text : `#${text}`;
+      if (/^\d+$/.test(text)) return `#ORD-${text.padStart(3, '0')}`;
+      return `#${text}`;
+    }
+
+    function deriveClientName(row, orderId) {
+      if (row.customerName) return String(row.customerName);
+      if (row.customerId !== null && row.customerId !== undefined && row.customerId !== '') {
+        return `Cliente ${row.customerId}`;
+      }
+      const idText = orderId !== undefined && orderId !== null ? String(orderId).trim() : '';
+      const displayId = idText ? (idText.startsWith('#') ? idText : `#${idText}`) : '#';
+      return `Orden ${displayId}`;
+    }
+
+    function normalizeStatus(status) {
+      if (status === null || status === undefined) return 'Procesando';
+      const raw = String(status).trim();
+      if (!raw) return 'Procesando';
+      const lower = raw.toLowerCase();
+      const mapping = {
+        'pagada': 'Pagada',
+        'pagado': 'Pagado',
+        'completado': 'Completado',
+        'completada': 'Completado',
+        'entregado': 'Entregado',
+        'enviado': 'Enviado',
+        'pendiente': 'Pendiente',
+        'procesando': 'Procesando',
+        'cancelado': 'Cancelado',
+        'cancelada': 'Cancelado',
+        'anulado': 'Anulado'
+      };
+      return mapping[lower] || capitalize(raw);
+    }
+
+    function statusBadge(status) {
+      const label = normalizeStatus(status);
+      const lower = label.toLowerCase();
+      const map = {
+        'completado': 'bg-green-100 text-green-800',
+        'pagado': 'bg-green-100 text-green-800',
+        'pagada': 'bg-green-100 text-green-800',
+        'entregado': 'bg-green-100 text-green-800',
+        'enviado': 'bg-blue-100 text-blue-800',
+        'procesando': 'bg-yellow-100 text-yellow-800',
+        'pendiente': 'bg-yellow-100 text-yellow-800',
+        'cancelado': 'bg-red-100 text-red-800',
+        'anulado': 'bg-red-100 text-red-800'
+      };
+      return `<span class="chip ${map[lower] || 'bg-gray-100 text-gray-800'}">${label}</span>`;
+    }
+
+    function buildProductLabel(items) {
+      if (!Array.isArray(items) || !items.length) return '-';
+      const [first, ...rest] = items;
+      if (!rest.length) return first.product || '-';
+      return `${first.product || '-'} +${rest.length}`;
+    }
+
+    function parseRowDate(row) {
+      if (row.date) {
+        const d = new Date(row.date);
+        if (!Number.isNaN(d.getTime())) return d;
+      }
+      if (row.year !== undefined && row.monthNumber !== undefined) {
+        const y = Number(row.year);
+        const m = Number(row.monthNumber);
+        if (!Number.isNaN(y) && !Number.isNaN(m)) {
+          return new Date(y, m - 1, 1);
+        }
+      }
+      return null;
+    }
+
+    function processDashboardRows(rows) {
+      const totals = { sales: 0 };
+      const monthMap = new Map();
+      const categoryMap = new Map();
+      const orderMap = new Map();
+      const clientMap = new Map();
+
+      rows.forEach((row, index) => {
+        const saleAmount = toNumber(row.sales);
+        totals.sales += saleAmount;
+
+        const rawOrderId = row.orderId ?? row.orden_id ?? row.order ?? row.id;
+        const orderKey = rawOrderId !== undefined && rawOrderId !== null && rawOrderId !== '' ? String(rawOrderId) : `tmp-${index}`;
+        const orderDisplayId = rawOrderId !== undefined && rawOrderId !== null && rawOrderId !== '' ? rawOrderId : orderKey;
+        const formattedOrderId = formatOrderDisplayId(orderDisplayId);
+
+        const customerName = row.customerName ? String(row.customerName).trim() : '';
+        const customerId = row.customerId ?? null;
+        const customerKey = customerId !== null && customerId !== undefined && customerId !== '' ? `id:${customerId}` : (customerName ? `name:${customerName}` : `order:${orderKey}`);
+        const clientDisplayName = customerName || deriveClientName({ customerName, customerId }, formattedOrderId);
+
+        const dateObj = parseRowDate(row);
+        const year = row.year !== undefined ? Number(row.year) : (dateObj ? dateObj.getFullYear() : null);
+        const monthNumber = row.monthNumber !== undefined ? Number(row.monthNumber) : (dateObj ? dateObj.getMonth() + 1 : null);
+        if (year !== null && monthNumber !== null) {
+          const monthKey = `${year}-${String(monthNumber).padStart(2, '0')}`;
+          if (!monthMap.has(monthKey)) {
+            monthMap.set(monthKey, {
+              key: monthKey,
+              year,
+              monthNumber,
+              ventas: 0,
+              orders: new Set(),
+              clients: new Set()
+            });
+          }
+          const monthEntry = monthMap.get(monthKey);
+          monthEntry.ventas += saleAmount;
+          monthEntry.orders.add(orderKey);
+          monthEntry.clients.add(customerKey);
+        }
+
+        const segment = row.segment ? String(row.segment) : 'General';
+        if (!categoryMap.has(segment)) {
+          categoryMap.set(segment, { sales: 0, units: 0 });
+        }
+        const categoryEntry = categoryMap.get(segment);
+        categoryEntry.sales += saleAmount;
+        categoryEntry.units += toNumber(row.unitsSold);
+
+        if (!orderMap.has(orderKey)) {
+          orderMap.set(orderKey, {
+            id: formattedOrderId,
+            rawId: orderDisplayId,
+            key: orderKey,
+            total: 0,
+            items: [],
+            status: row.orderStatus ?? null,
+            customerKey,
+            customerId,
+            customerName: customerName || null,
+            date: dateObj,
+            dateString: row.date && String(row.date) ? String(row.date) : (dateObj ? formatDateISO(dateObj) : '')
+          });
+        }
+        const order = orderMap.get(orderKey);
+        order.total += saleAmount;
+        order.items.push({ product: row.product, amount: saleAmount });
+        if (!order.customerName && customerName) {
+          order.customerName = customerName;
+        }
+        if (row.orderStatus && !order.status) {
+          order.status = row.orderStatus;
+        }
+        if (dateObj && (!order.date || dateObj > order.date)) {
+          order.date = dateObj;
+          order.dateString = row.date && String(row.date) ? String(row.date) : formatDateISO(dateObj);
+        }
+
+        if (!clientMap.has(customerKey)) {
+          clientMap.set(customerKey, {
+            name: clientDisplayName,
+            orders: new Set(),
+            total: 0,
+            lastDate: dateObj,
+            lastDateString: order.dateString
+          });
+        }
+        const client = clientMap.get(customerKey);
+        client.total += saleAmount;
+        client.orders.add(orderKey);
+        if (order.date && (!client.lastDate || order.date > client.lastDate)) {
+          client.lastDate = order.date;
+          client.lastDateString = order.dateString;
+        }
+      });
+
+      const months = Array.from(monthMap.values())
+        .sort((a, b) => (a.year === b.year ? a.monthNumber - b.monthNumber : a.year - b.year))
+        .map(entry => ({
+          month: formatMonthLabel(entry.year, entry.monthNumber),
+          ventas: entry.ventas,
+          ordenes: entry.orders.size,
+          clientes: entry.clients.size,
+          year: entry.year,
+          monthNumber: entry.monthNumber
+        }));
+
+      const totalCategorySales = Array.from(categoryMap.values()).reduce((sum, c) => sum + c.sales, 0);
+      const palette = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300', '#8dd1e1', '#6366f1', '#ec4899', '#f97316'];
+      const categories = Array.from(categoryMap.entries())
+        .sort((a, b) => b[1].sales - a[1].sales)
+        .map(([name, info], idx) => ({
+          name,
+          sales: info.sales,
+          units: info.units,
+          percent: totalCategorySales > 0 ? (info.sales / totalCategorySales) * 100 : 0,
+          color: palette[idx % palette.length]
+        }));
+
+      const clients = Array.from(clientMap.values())
+        .map(client => ({
+          nombre: client.name,
+          compras: client.orders.size,
+          total: client.total,
+          ultimaCompra: client.lastDateString || ''
+        }))
+        .sort((a, b) => b.total - a.total);
+
+      const orders = Array.from(orderMap.values())
+        .sort((a, b) => {
+          const aTime = a.date ? a.date.getTime() : 0;
+          const bTime = b.date ? b.date.getTime() : 0;
+          return bTime - aTime;
+        })
+        .map(order => ({
+          id: order.id,
+          rawId: order.rawId,
+          cliente: order.customerName || deriveClientName({ customerName: order.customerName, customerId: order.customerId }, order.id),
+          producto: buildProductLabel(order.items),
+          monto: order.total,
+          estado: normalizeStatus(order.status),
+          fecha: order.dateString || ''
+        }));
+
+      return {
+        months,
+        categories,
+        clients,
+        orders,
+        totals: {
+          sales: totals.sales,
+          orders: orderMap.size,
+          clients: clientMap.size
+        }
+      };
+    }
+
+    function applyDashboardData(rows) {
+      const state = processDashboardRows(Array.isArray(rows) ? rows : []);
+      salesData = state.months;
+      productCategories = state.categories;
+      topClients = state.clients;
+      recentOrders = state.orders;
+      dashboardTotals = state.totals;
+      renderDashboard();
+    }
 
     function calcMetrics() {
-      const totalSales = salesData.reduce((s, x) => s + x.ventas, 0);
-      const totalOrders = salesData.reduce((s, x) => s + x.ordenes, 0);
-      const totalClients = salesData.reduce((s, x) => Math.max(s, x.clientes), 0);
-      const avgOrderValue = totalSales / totalOrders;
-      const last = salesData[salesData.length - 1];
-      const prev = salesData[salesData.length - 2];
-      const salesGrowth = ((last.ventas - prev.ventas) / prev.ventas) * 100;
-      const ordersGrowth = ((last.ordenes - prev.ordenes) / prev.ordenes) * 100;
+      const totalSales = dashboardTotals.sales || 0;
+      const totalOrders = dashboardTotals.orders || 0;
+      const totalClients = dashboardTotals.clients || 0;
+      const avgOrderValue = totalOrders > 0 ? totalSales / totalOrders : 0;
+
+      const last = salesData[salesData.length - 1] || null;
+      const prev = salesData[salesData.length - 2] || null;
+
+      const salesGrowth = prev && prev.ventas ? ((last.ventas - prev.ventas) / prev.ventas) * 100 : 0;
+      const ordersGrowth = prev && prev.ordenes ? ((last.ordenes - prev.ordenes) / prev.ordenes) * 100 : 0;
+
       return { totalSales, totalOrders, totalClients, avgOrderValue, salesGrowth, ordersGrowth };
     }
 
     function renderMetricGrowth(el, value) {
+      if (!el) return;
+      const safeValue = Number.isFinite(value) ? value : 0;
       el.innerHTML = '';
       const icon = document.createElement('i');
-      icon.setAttribute('data-lucide', value >= 0 ? 'trending-up' : 'trending-down');
+      icon.setAttribute('data-lucide', safeValue >= 0 ? 'trending-up' : 'trending-down');
       icon.className = 'w-4 h-4';
       const span = document.createElement('span');
       span.className = 'ml-1';
-      span.textContent = `${Math.abs(value).toFixed(1)}% vs mes anterior`;
+      span.textContent = `${Math.abs(safeValue).toFixed(1)}% vs mes anterior`;
       el.append(icon, span);
-      el.className = `flex items-center mt-1 text-sm ${value >= 0 ? 'text-green-600' : 'text-red-600'}`;
+      el.className = `flex items-center mt-1 text-sm ${safeValue >= 0 ? 'text-green-600' : 'text-red-600'}`;
       lucide.createIcons();
     }
 
-    // ===== Render Métricas =====
-    const { totalSales, totalOrders, totalClients, avgOrderValue, salesGrowth, ordersGrowth } = calcMetrics();
-    document.getElementById('metricTotalSales').textContent = fmtCurrency(totalSales);
-    renderMetricGrowth(document.getElementById('metricSalesGrowth'), salesGrowth);
-    document.getElementById('metricTotalOrders').textContent = fmtNumber(totalOrders);
-    renderMetricGrowth(document.getElementById('metricOrdersGrowth'), ordersGrowth);
-    document.getElementById('metricTotalClients').textContent = fmtNumber(totalClients);
-    document.getElementById('metricAOV').textContent = fmtCurrency(avgOrderValue);
-    document.getElementById('metricAOV2').textContent = fmtCurrency(avgOrderValue);
+    function renderTopCategoriesSection() {
+      const container = document.getElementById('topCategories');
+      if (!container) return;
+      if (!productCategories.length) {
+        container.innerHTML = '<p class="text-sm text-gray-500">Sin datos disponibles.</p>';
+        return;
+      }
+      container.innerHTML = productCategories.slice(0, 5).map(cat => `
+        <div class="flex items-center justify-between">
+          <div class="flex items-center">
+            <div class="w-4 h-4 rounded-full mr-3" style="background:${cat.color}"></div>
+            <span class="font-medium">${cat.name}</span>
+          </div>
+          <div class="text-right">
+            <div class="font-semibold">${fmtCurrency(cat.sales)}</div>
+            <div class="text-sm text-gray-500">${cat.percent.toFixed(1)}%</div>
+          </div>
+        </div>
+      `).join('');
+    }
 
-    // ===== Charts =====
-    let chartTrend, chartCategories, chartSalesBars, chartInventory;
+    function renderClientsTable() {
+      const tbl = document.getElementById('tblTopClients');
+      if (!tbl) return;
+      if (!topClients.length) {
+        tbl.innerHTML = '<tr class="border-b border-gray-100"><td colspan="4" class="py-6 px-4 text-center text-sm text-gray-500">Sin datos disponibles.</td></tr>';
+        return;
+      }
+      tbl.innerHTML = topClients.slice(0, 5).map(client => {
+        const initial = client.nombre ? client.nombre.charAt(0).toUpperCase() : '#';
+        return `
+          <tr class="border-b border-gray-100 hover:bg-gray-50">
+            <td class="py-3 px-4">
+              <div class="flex items-center">
+                <div class="w-8 h-8 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center text-white font-semibold mr-3">${initial}</div>
+                ${client.nombre}
+              </div>
+            </td>
+            <td class="py-3 px-4">${fmtNumber(client.compras)}</td>
+            <td class="py-3 px-4 font-semibold">${fmtCurrency(client.total)}</td>
+            <td class="py-3 px-4 text-gray-600">${client.ultimaCompra || '-'}</td>
+          </tr>
+        `;
+      }).join('');
+    }
+
+    function renderOrdersTable() {
+      const tbl = document.getElementById('tblOrders');
+      if (!tbl) return;
+      if (!recentOrders.length) {
+        tbl.innerHTML = '<tr class="border-b border-gray-100"><td colspan="6" class="py-6 px-4 text-center text-sm text-gray-500">Sin datos disponibles.</td></tr>';
+        return;
+      }
+      tbl.innerHTML = recentOrders.slice(0, 8).map(order => `
+        <tr class="border-b border-gray-100 hover:bg-gray-50">
+          <td class="py-3 px-4 font-mono text-sm">${order.id}</td>
+          <td class="py-3 px-4">${order.cliente}</td>
+          <td class="py-3 px-4">${order.producto}</td>
+          <td class="py-3 px-4 font-semibold">${fmtCurrency(order.monto)}</td>
+          <td class="py-3 px-4">${statusBadge(order.estado)}</td>
+          <td class="py-3 px-4 text-gray-600">${order.fecha || '-'}</td>
+        </tr>
+      `).join('');
+    }
+
+    function renderInventoryAlerts() {
+      const container = document.getElementById('alertsInventory');
+      if (!container) return;
+      if (!productCategories.length) {
+        container.innerHTML = `
+          <div class="flex items-center justify-between p-3 bg-gray-50 border border-gray-200 rounded-lg">
+            <span class="text-gray-700">Sin datos disponibles</span>
+            <span class="text-gray-600 font-semibold">N/A</span>
+          </div>
+        `;
+        return;
+      }
+      const unitsData = productCategories.map(cat => ({ name: cat.name, units: cat.units }));
+      const totalUnits = unitsData.reduce((sum, item) => sum + item.units, 0);
+      const averageUnits = unitsData.length ? totalUnits / unitsData.length : 0;
+      const alerts = unitsData
+        .filter(item => averageUnits === 0 || item.units <= averageUnits * 1.1)
+        .sort((a, b) => a.units - b.units)
+        .slice(0, 3);
+
+      const alertMarkup = alerts.map(alert => {
+        const ratio = averageUnits > 0 ? alert.units / averageUnits : 0;
+        let styles = { bg: 'bg-green-50', border: 'border-green-200', text: 'text-green-700', accent: 'text-green-600', label: 'Movimiento saludable' };
+        if (ratio <= 0.5) {
+          styles = { bg: 'bg-red-50', border: 'border-red-200', text: 'text-red-700', accent: 'text-red-600', label: 'Bajo movimiento' };
+        } else if (ratio <= 0.85) {
+          styles = { bg: 'bg-yellow-50', border: 'border-yellow-200', text: 'text-yellow-700', accent: 'text-yellow-600', label: 'Movimiento moderado' };
+        }
+        return `
+          <div class="flex items-center justify-between p-3 ${styles.bg} border ${styles.border} rounded-lg">
+            <span class="${styles.text}">${alert.name}</span>
+            <span class="${styles.accent} font-semibold">${styles.label}: ${fmtNumber(Math.round(alert.units))}</span>
+          </div>
+        `;
+      }).join('');
+
+      container.innerHTML = alertMarkup || `
+        <div class="flex items-center justify-between p-3 bg-green-50 border border-green-200 rounded-lg">
+          <span class="text-green-700">Inventario sin alertas</span>
+          <span class="text-green-600 font-semibold">${fmtNumber(Math.round(averageUnits))} unidades promedio</span>
+        </div>
+      `;
+    }
+
+    function renderDashboard() {
+      const metrics = calcMetrics();
+      const totalSalesEl = document.getElementById('metricTotalSales');
+      if (totalSalesEl) totalSalesEl.textContent = fmtCurrency(metrics.totalSales);
+      renderMetricGrowth(document.getElementById('metricSalesGrowth'), metrics.salesGrowth);
+      const totalOrdersEl = document.getElementById('metricTotalOrders');
+      if (totalOrdersEl) totalOrdersEl.textContent = fmtNumber(metrics.totalOrders);
+      renderMetricGrowth(document.getElementById('metricOrdersGrowth'), metrics.ordersGrowth);
+      const totalClientsEl = document.getElementById('metricTotalClients');
+      if (totalClientsEl) totalClientsEl.textContent = fmtNumber(metrics.totalClients);
+      const aovValue = fmtCurrency(metrics.avgOrderValue || 0);
+      const aovEl = document.getElementById('metricAOV');
+      const aov2El = document.getElementById('metricAOV2');
+      if (aovEl) aovEl.textContent = aovValue;
+      if (aov2El) aov2El.textContent = aovValue;
+
+      renderTopCategoriesSection();
+      renderClientsTable();
+      renderOrdersTable();
+      renderInventoryAlerts();
+
+      const salesTab = document.getElementById('tab-sales');
+      const productsTab = document.getElementById('tab-products');
+      const currentPeriod = periodSelect ? periodSelect.value : '9m';
+      createTrend(currentPeriod);
+      createCategories();
+      if (salesTab && !salesTab.classList.contains('hidden')) {
+        createSalesBars();
+      }
+      if (productsTab && !productsTab.classList.contains('hidden')) {
+        createInventory();
+      }
+
+      lucide.createIcons();
+    }
 
     function buildTrendData(period) {
       const map = { '3m': 3, '6m': 6, '9m': 9, '12m': 12 };
       const n = map[period] || 9;
       const slice = salesData.slice(-n);
+      if (!slice.length) {
+        return {
+          labels: ['Sin datos'],
+          datasets: [{
+            label: 'Ventas ($)',
+            data: [0],
+            fill: true,
+            tension: 0.35,
+            borderWidth: 2,
+            pointRadius: 3,
+            backgroundColor: 'rgba(136, 132, 216, 0.15)',
+            borderColor: '#8884d8'
+          }]
+        };
+      }
       return {
         labels: slice.map(x => x.month),
         datasets: [{
@@ -329,10 +725,11 @@
           borderWidth: 2,
           pointRadius: 3,
           backgroundColor: ctx => {
-            const { chart } = ctx; const { ctx: c } = chart; const g = c.createLinearGradient(0, 0, 0, 300);
-            g.addColorStop(0, 'rgba(136, 132, 216, 0.35)');
-            g.addColorStop(1, 'rgba(136, 132, 216, 0.05)');
-            return g;
+            const { chart } = ctx;
+            const gradient = chart.ctx.createLinearGradient(0, 0, 0, 300);
+            gradient.addColorStop(0, 'rgba(136, 132, 216, 0.35)');
+            gradient.addColorStop(1, 'rgba(136, 132, 216, 0.05)');
+            return gradient;
           },
           borderColor: '#8884d8'
         }]
@@ -341,10 +738,12 @@
 
     function createTrend(period) {
       const ctx = document.getElementById('chartTrend');
+      if (!ctx) return;
       if (chartTrend) chartTrend.destroy();
+      const data = buildTrendData(period);
       chartTrend = new Chart(ctx, {
         type: 'line',
-        data: buildTrendData(period),
+        data,
         options: {
           responsive: true,
           maintainAspectRatio: false,
@@ -362,13 +761,25 @@
 
     function createCategories() {
       const ctx = document.getElementById('chartCategories');
+      if (!ctx) return;
       if (chartCategories) chartCategories.destroy();
+      if (!productCategories.length) {
+        chartCategories = new Chart(ctx, {
+          type: 'pie',
+          data: {
+            labels: ['Sin datos'],
+            datasets: [{ data: [1], backgroundColor: ['#e5e7eb'], borderWidth: 0 }]
+          },
+          options: { responsive: true, maintainAspectRatio: false }
+        });
+        return;
+      }
       chartCategories = new Chart(ctx, {
         type: 'pie',
         data: {
-          labels: productCategories.map(c => `${c.name} (${c.value}%)`),
+          labels: productCategories.map(c => `${c.name} (${c.percent.toFixed(1)}%)`),
           datasets: [{
-            data: productCategories.map(c => c.value),
+            data: productCategories.map(c => Number(c.percent.toFixed(2))),
             backgroundColor: productCategories.map(c => c.color),
             borderWidth: 0
           }]
@@ -379,18 +790,23 @@
 
     function createSalesBars() {
       const ctx = document.getElementById('chartSalesBars');
+      if (!ctx) return;
       if (chartSalesBars) chartSalesBars.destroy();
+      const labels = salesData.length ? salesData.map(x => x.month) : ['Sin datos'];
+      const ventas = salesData.length ? salesData.map(x => x.ventas) : [0];
+      const ordenes = salesData.length ? salesData.map(x => x.ordenes) : [0];
       chartSalesBars = new Chart(ctx, {
         type: 'bar',
         data: {
-          labels: salesData.map(x => x.month),
+          labels,
           datasets: [
-            { label: 'Ventas ($)', data: salesData.map(x => x.ventas), backgroundColor: '#8884d8' },
-            { label: 'Órdenes', data: salesData.map(x => x.ordenes), backgroundColor: '#82ca9d' }
+            { label: 'Ventas ($)', data: ventas, backgroundColor: '#8884d8' },
+            { label: 'Órdenes', data: ordenes, backgroundColor: '#82ca9d' }
           ]
         },
         options: {
-          responsive: true, maintainAspectRatio: false,
+          responsive: true,
+          maintainAspectRatio: false,
           plugins: { legend: { position: 'bottom' } },
           scales: { x: { stacked: false }, y: { beginAtZero: true } }
         }
@@ -399,93 +815,69 @@
 
     function createInventory() {
       const ctx = document.getElementById('chartInventory');
+      if (!ctx) return;
       if (chartInventory) chartInventory.destroy();
       const data = productCategories.slice(0, 4);
+      const labels = data.length ? data.map(x => x.name) : ['Sin datos'];
+      const units = data.length ? data.map(x => x.units) : [0];
       chartInventory = new Chart(ctx, {
         type: 'bar',
         data: {
-          labels: data.map(x => x.name),
-          datasets: [{ label: 'Stock (unidades)', data: data.map(x => x.value), backgroundColor: '#8884d8' }]
+          labels,
+          datasets: [{ label: 'Unidades vendidas', data: units, backgroundColor: '#8884d8' }]
         },
         options: { responsive: true, maintainAspectRatio: false }
       });
     }
 
-    // Inicializar charts de Overview
-    createTrend('9m');
-    createCategories();
-
-    // Contenido dinámico de "Top 5 Categorías"
-    const topC = document.getElementById('topCategories');
-    topC.innerHTML = productCategories.map(cat => `
-      <div class="flex items-center justify-between">
-        <div class="flex items-center">
-          <div class="w-4 h-4 rounded-full mr-3" style="background:${cat.color}"></div>
-          <span class="font-medium">${cat.name}</span>
+    function showErrorState(message) {
+      const container = document.getElementById('alertsInventory');
+      if (!container) return;
+      container.innerHTML = `
+        <div class="flex items-center justify-between p-3 bg-red-50 border border-red-200 rounded-lg">
+          <span class="text-red-700">No se pudieron cargar los datos</span>
+          <span class="text-red-600 font-semibold">${message}</span>
         </div>
-        <div class="text-right">
-          <div class="font-semibold">${fmtCurrency(cat.ventas)}</div>
-          <div class="text-sm text-gray-500">${cat.value}%</div>
-        </div>
-      </div>
-    `).join('');
-
-    // Tabla Top Clientes
-    const tblTop = document.getElementById('tblTopClients');
-    tblTop.innerHTML = topClients.map(c => `
-      <tr class="border-b border-gray-100 hover:bg-gray-50">
-        <td class="py-3 px-4">
-          <div class="flex items-center">
-            <div class="w-8 h-8 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center text-white font-semibold mr-3">${c.nombre.charAt(0)}</div>
-            ${c.nombre}
-          </div>
-        </td>
-        <td class="py-3 px-4">${c.compras}</td>
-        <td class="py-3 px-4 font-semibold">${fmtCurrency(c.total)}</td>
-        <td class="py-3 px-4 text-gray-600">${c.ultimaCompra}</td>
-      </tr>
-    `).join('');
-
-    // Tabla Órdenes + Badges de estado
-    function statusBadge(status) {
-      const map = {
-        'Completado': 'bg-green-100 text-green-800',
-        'Procesando': 'bg-yellow-100 text-yellow-800',
-        'Enviado': 'bg-blue-100 text-blue-800',
-        'Cancelado': 'bg-red-100 text-red-800'
-      };
-      return `<span class="chip ${map[status] || 'bg-gray-100 text-gray-800'}">${status}</span>`;
+      `;
     }
 
-    const tblOrders = document.getElementById('tblOrders');
-    tblOrders.innerHTML = recentOrders.map(o => `
-      <tr class="border-b border-gray-100 hover:bg-gray-50">
-        <td class="py-3 px-4 font-mono text-sm">${o.id}</td>
-        <td class="py-3 px-4">${o.cliente}</td>
-        <td class="py-3 px-4">${o.producto}</td>
-        <td class="py-3 px-4 font-semibold">${fmtCurrency(o.monto)}</td>
-        <td class="py-3 px-4">${statusBadge(o.estado)}</td>
-        <td class="py-3 px-4 text-gray-600">${o.fecha}</td>
-      </tr>
-    `).join('');
+    async function loadDashboard(isRefresh = false) {
+      if (refreshBtn && isRefresh) {
+        refreshBtn.disabled = true;
+        refreshBtn.classList.add('opacity-60', 'cursor-not-allowed');
+      }
+      try {
+        const response = await fetch('api/dashboard-data.php');
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const payload = await response.json();
+        applyDashboardData(payload.rows || []);
+      } catch (error) {
+        console.error('Error cargando datos del dashboard', error);
+        applyDashboardData([]);
+        showErrorState(error.message || 'Error inesperado');
+      } finally {
+        if (refreshBtn) {
+          refreshBtn.disabled = false;
+          refreshBtn.classList.remove('opacity-60', 'cursor-not-allowed');
+        }
+      }
+    }
 
-    // Alertas de inventario (estáticas de demostración)
-    document.getElementById('alertsInventory').innerHTML = `
-      <div class="flex items-center justify-between p-3 bg-red-50 border border-red-200 rounded-lg">
-        <span class="text-red-700">Anillo Diamante Solitario</span>
-        <span class="text-red-600 font-semibold">Stock Bajo: 3</span>
-      </div>
-      <div class="flex items-center justify-between p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
-        <span class="text-yellow-700">Collar Perlas Cultivo</span>
-        <span class="text-yellow-600 font-semibold">Stock Medio: 8</span>
-      </div>
-      <div class="flex items-center justify-between p-3 bg-green-50 border border-green-200 rounded-lg">
-        <span class="text-green-700">Pulsera Plata 925</span>
-        <span class="text-green-600 font-semibold">Stock OK: 15</span>
-      </div>
-    `;
+    if (refreshBtn) {
+      refreshBtn.addEventListener('click', () => loadDashboard(true));
+    }
 
-    // ===== Tab logic =====
+    if (exportBtn) {
+      exportBtn.addEventListener('click', () => {
+        if (!chartTrend) return;
+        const canvas = chartTrend.canvas;
+        const link = document.createElement('a');
+        link.download = 'ventas_tendencia.png';
+        link.href = canvas.toDataURL('image/png');
+        link.click();
+      });
+    }
+
     const tabs = ['overview', 'sales', 'customers', 'products'];
     document.querySelectorAll('.tab-btn').forEach(btn => {
       btn.addEventListener('click', () => {
@@ -493,40 +885,21 @@
         tabs.forEach(t => {
           document.getElementById(`tab-${t}`).classList.toggle('hidden', t !== key);
         });
-        // estilos activos
         document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('bg-white','text-purple-600','shadow'));
         btn.classList.add('bg-white','text-purple-600','shadow');
-        // crear charts de cada tab si hace falta
         if (key === 'sales') createSalesBars();
         if (key === 'products') createInventory();
       });
     });
 
-    // Cambiar período del gráfico de tendencia
-    document.getElementById('periodSelect').addEventListener('change', (e) => {
-      createTrend(e.target.value);
-    });
+    if (periodSelect) {
+      periodSelect.addEventListener('change', (e) => {
+        createTrend(e.target.value);
+      });
+    }
 
-    // Botones (demo)
-    document.getElementById('btnRefresh').addEventListener('click', () => {
-      // En una app real, aquí refrescarías datos del servidor
-      createTrend(document.getElementById('periodSelect').value);
-      createCategories();
-      if (!document.getElementById('tab-sales').classList.contains('hidden')) createSalesBars();
-      if (!document.getElementById('tab-products').classList.contains('hidden')) createInventory();
-    });
-
-    document.getElementById('btnExport').addEventListener('click', () => {
-      // Export simple del área visible como imagen (canvas principal)
-      const canvas = document.querySelector('#chartTrend');
-      const link = document.createElement('a');
-      link.download = 'ventas_tendencia.png';
-      link.href = canvas.toDataURL('image/png');
-      link.click();
-    });
-
-    // Render icons
     lucide.createIcons();
+    loadDashboard();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enrich `api/dashboard-data.php` with optional customer joins and order metadata for downstream consumers
- refactor `reporteria.html` to fetch dashboard data from the API and dynamically render metrics, charts, and tables

## Testing
- php -l api/dashboard-data.php

------
https://chatgpt.com/codex/tasks/task_e_68e09c762fe08325acc1399cc9cede61