### PR TITLE
Add vendor sales management section

### DIFF
--- a/Js/auth.js
+++ b/Js/auth.js
@@ -12,7 +12,14 @@ function saveSession({ token, user }) {
 }
 
 function redirectByRole(role) {
-  window.location.href = (role === 'admin') ? 'admin.html' : 'index.html';
+  const normalized = (role || '').toString().trim().toLowerCase();
+  if (normalized === 'admin') {
+    window.location.href = 'admin.html';
+  } else if (normalized === 'vendedor' || normalized === 'seller') {
+    window.location.href = 'ventas.html';
+  } else {
+    window.location.href = 'index.html';
+  }
 }
 
 function showError(msg){ alert(msg || 'Error inesperado'); }

--- a/Js/vendor-sales.js
+++ b/Js/vendor-sales.js
@@ -1,73 +1,37 @@
-const API_BASE = 'https://joyeria-full-stack-production.up.railway.app'; // ✅
-
-/* ====== Guardas de sesión ====== */
+const allowedVendorRoles = new Set(['vendedor', 'seller']);
 const token = localStorage.getItem('token');
-const role  = localStorage.getItem('role');
-// En auth.js guardas con la clave 'email', no 'userEmail'
-const email = localStorage.getItem('email'); // ✅
+const storedRole = localStorage.getItem('role');
+const normalizedRole = (storedRole || '').trim().toLowerCase();
 
-if (!token || role !== 'admin') {
-  const next = encodeURIComponent('admin.html');
+if (!token || !allowedVendorRoles.has(normalizedRole)) {
+  const next = encodeURIComponent('ventas.html');
   window.location.href = `login.html?next=${next}`;
 }
 
-document.getElementById('adminEmail').textContent = email || '';
+const vendorName = localStorage.getItem('name') || '—';
+const vendorEmail = localStorage.getItem('email') || '—';
 
-document.getElementById('logoutBtn').addEventListener('click', () => {
+const vendorNameLabel = document.getElementById('vendorName');
+const vendorEmailLabel = document.getElementById('vendorEmail');
+
+if (vendorNameLabel) vendorNameLabel.textContent = vendorName;
+if (vendorEmailLabel) vendorEmailLabel.textContent = vendorEmail;
+
+document.getElementById('logoutVendor')?.addEventListener('click', () => {
   localStorage.removeItem('token');
   localStorage.removeItem('role');
-  localStorage.removeItem('email'); // ✅ coherente con auth.js
+  localStorage.removeItem('name');
+  localStorage.removeItem('email');
   window.location.href = 'index.html';
 });
 
-/* ====== UI refs ====== */
-const $tbody        = document.querySelector('#tblProductos tbody');
-const $ordersTbody  = document.querySelector('#tblPedidos tbody');
-const salesNavBtn   = document.querySelector('.nav-btn[data-section="sales"]');
-const $modal        = $('#modalProducto');
-const $frm          = document.getElementById('frmProducto');
-const money         = new Intl.NumberFormat('es-GT', { style:'currency', currency:'GTQ' });
-
-/* Dropzone refs */
-const dropZone   = document.getElementById('dropZone');
-const fileInput  = document.getElementById('fileInput');
-const imgPreview = document.getElementById('imgPreview');
-
-/* ====== Helpers HTTP ====== */
-async function apiFetch(path, options = {}) {
-  const res = await fetch(`${API_BASE}${path}`, options);
-  const data = await res.json().catch(() => ({}));
-  if (!res.ok) throw new Error(data.error || data.message || `HTTP ${res.status}`);
-  return data;
-}
-
-/* ====== Tabla ====== */
-function rowHTML(p) {
-  return `
-    <tr data-id="${p.Id}">
-      <td>${p.Id}</td>
-      <td>${p.Codigo ?? ''}</td>
-      <td>${p.Nombre}</td>
-      <td>${money.format(p.Precio)}</td>
-      <td>${p.Stock}</td>
-      <td>${Number(p.Activo) ? 'Sí' : 'No'}</td>
-      <td class="text-right">
-        <button class="btn btn-sm btn-outline-secondary btn-edit">Editar</button>
-        <button class="btn btn-sm btn-outline-danger btn-del">Borrar</button>
-      </td>
-    </tr>
-  `;
-}
-
-
-const numberFormatter = new Intl.NumberFormat('es-GT', { minimumFractionDigits: 0, maximumFractionDigits: 2 });
-const dateTimeFormatter = new Intl.DateTimeFormat('es-GT', { dateStyle: 'medium', timeStyle: 'short' });
-
+const $ordersTbody = document.querySelector('#tblPedidos tbody');
 const ordersAlert = document.getElementById('ordersAlert');
 const ordersReloadBtn = document.getElementById('btnPedidosReload');
 const ordersSearchInput = document.getElementById('ordersSearch');
 const ordersClearBtn = document.getElementById('ordersClearFilters');
 const ordersStatusCheckboxes = document.querySelectorAll('[data-order-status-filter]');
+
 const orderModalElement = document.getElementById('modalPedidoEstado');
 const orderModal = $('#modalPedidoEstado');
 const orderModalForm = document.getElementById('frmPedidoEstado');
@@ -91,6 +55,10 @@ const orderNotesInput = document.getElementById('orderNotes');
 const orderModalCancelBtn = document.getElementById('orderModalCancelBtn');
 const orderModalSubmitBtn = document.getElementById('orderModalSubmitBtn');
 
+const money = new Intl.NumberFormat('es-GT', { style: 'currency', currency: 'GTQ' });
+const numberFormatter = new Intl.NumberFormat('es-GT', { minimumFractionDigits: 0, maximumFractionDigits: 2 });
+const dateTimeFormatter = new Intl.DateTimeFormat('es-GT', { dateStyle: 'medium', timeStyle: 'short' });
+
 const DEFAULT_ORDER_STATUSES = ['pendiente', 'enviado'];
 const ordersState = {
   list: [],
@@ -99,8 +67,8 @@ const ordersState = {
   search: '',
 };
 
-let ordersAlertTimer = null;
 let currentOrderDetail = null;
+let ordersAlertTimer = null;
 
 function escapeHtml(value) {
   if (value === null || value === undefined) return '';
@@ -162,11 +130,6 @@ function parseDateValue(value) {
   if (!Number.isNaN(date.getTime())) return date;
   const fallback = new Date(value);
   return Number.isNaN(fallback.getTime()) ? null : fallback;
-}
-
-function getTimestamp(value) {
-  const date = parseDateValue(value);
-  return date ? date.getTime() : 0;
 }
 
 function formatDateTime(value) {
@@ -359,33 +322,51 @@ function renderOrders() {
       return haystack.includes(searchTerm);
     })
     .sort((a, b) => {
-      const bTime = getTimestamp(b.updated_at || b.delivery?.updated_at || b.delivery?.paid_at || b.delivery?.shipped_at || b.created_at);
-      const aTime = getTimestamp(a.updated_at || a.delivery?.updated_at || a.delivery?.paid_at || a.delivery?.shipped_at || a.created_at);
-      if (bTime !== aTime) return bTime - aTime;
-      return (b.id || 0) - (a.id || 0);
+      const aDate = parseDateValue(a.delivery?.updated_at || a.updated_at || a.delivery?.paid_at || a.delivery?.shipped_at || a.created_at);
+      const bDate = parseDateValue(b.delivery?.updated_at || b.updated_at || b.delivery?.paid_at || b.delivery?.shipped_at || b.created_at);
+      return (bDate?.getTime() || 0) - (aDate?.getTime() || 0);
     });
 
   if (!filtered.length) {
-    $ordersTbody.innerHTML = `<tr><td colspan="8" class="text-center text-muted py-4">No se encontraron pedidos con los filtros seleccionados.</td></tr>`;
+    $ordersTbody.innerHTML = `
+      <tr>
+        <td colspan="8" class="text-center text-muted py-4">No se encontraron pedidos con los filtros seleccionados.</td>
+      </tr>
+    `;
     return;
   }
 
   $ordersTbody.innerHTML = filtered.map(pedidoRowHTML).join('');
 }
 
-function showOrdersAlert(type, message, options = {}) {
+function setLoadingButton(btn, loading, text = 'Guardando...') {
+  if (!btn) return;
+  if (loading) {
+    if (!btn.dataset.originalHtml) {
+      btn.dataset.originalHtml = btn.innerHTML;
+    }
+    btn.innerHTML = `<span class="spinner-border spinner-border-sm mr-2" role="status" aria-hidden="true"></span>${text}`;
+    btn.disabled = true;
+  } else {
+    if (btn.dataset.originalHtml) {
+      btn.innerHTML = btn.dataset.originalHtml;
+      delete btn.dataset.originalHtml;
+    }
+    btn.disabled = false;
+  }
+}
+
+function showOrdersAlert(type, message) {
   if (!ordersAlert) return;
   ordersAlert.className = `alert alert-${type}`;
   ordersAlert.textContent = message;
   ordersAlert.classList.remove('d-none');
-  if (ordersAlertTimer) clearTimeout(ordersAlertTimer);
-  const autoHide = options.autoHide !== undefined ? options.autoHide : type === 'success';
-  if (autoHide) {
-    const timeout = options.timeout ?? 4000;
-    ordersAlertTimer = window.setTimeout(() => {
-      hideOrdersAlert();
-    }, timeout);
+  if (ordersAlertTimer) {
+    clearTimeout(ordersAlertTimer);
   }
+  ordersAlertTimer = window.setTimeout(() => {
+    hideOrdersAlert();
+  }, 6000);
 }
 
 function hideOrdersAlert() {
@@ -411,44 +392,25 @@ function hideOrderModalAlert() {
   orderModalAlert.textContent = '';
 }
 
-function setLoadingButton(btn, isLoading, loadingText = 'Procesando...') {
-  if (!btn) return;
-  if (isLoading) {
-    if (!btn.dataset.originalHtml) {
-      btn.dataset.originalHtml = btn.innerHTML;
-    }
-    btn.disabled = true;
-    btn.innerHTML = `<span class="spinner-border spinner-border-sm mr-2" role="status" aria-hidden="true"></span>${loadingText}`;
-  } else {
-    if (btn.dataset.originalHtml) {
-      btn.innerHTML = btn.dataset.originalHtml;
-      delete btn.dataset.originalHtml;
-    }
-    btn.disabled = false;
+function setOrderModalFetching(isFetching) {
+  if (orderModalSubmitBtn) {
+    setLoadingButton(orderModalSubmitBtn, isFetching, 'Cargando...');
+  }
+  if (orderModalCancelBtn) {
+    orderModalCancelBtn.disabled = isFetching;
   }
 }
 
-function setOrderModalDisabled(disabled) {
-  [orderStatusSelect, orderDeliveryNameInput, orderDeliveryContactInput, orderPaymentConfirmedInput, orderNotesInput].forEach(el => {
-    if (el) el.disabled = disabled;
-  });
-}
-
-function setOrderModalFetching(isFetching) {
-  setLoadingButton(orderModalSubmitBtn, isFetching, 'Cargando...');
-  if (orderModalCancelBtn) orderModalCancelBtn.disabled = isFetching;
-  setOrderModalDisabled(isFetching);
-}
-
 function setOrderModalLoading(isLoading) {
-  setLoadingButton(orderModalSubmitBtn, isLoading, 'Guardando...');
-  if (orderModalCancelBtn) orderModalCancelBtn.disabled = isLoading;
-  setOrderModalDisabled(isLoading);
+  if (orderModalSubmitBtn) {
+    setLoadingButton(orderModalSubmitBtn, isLoading, 'Guardando...');
+  }
+  if (orderModalCancelBtn) {
+    orderModalCancelBtn.disabled = isLoading;
+  }
 }
 
 function resetOrderModal() {
-  currentOrderDetail = null;
-  hideOrderModalAlert();
   if (orderModalForm) {
     orderModalForm.reset();
     orderModalForm.dataset.orderId = '';
@@ -469,37 +431,12 @@ function resetOrderModal() {
     setLoadingButton(orderModalSubmitBtn, false);
   }
   if (orderModalCancelBtn) orderModalCancelBtn.disabled = false;
-  setOrderModalDisabled(false);
-}
-
-async function fetchOrderDetail(orderId) {
-  const url = `/api/orders.php?id=${orderId}&with=items`;
-  const res = await fetch(url, { headers: { 'Accept': 'application/json' } });
-  const data = await res.json().catch(() => ({}));
-  if (!res.ok || data.error) {
-    throw new Error(data.error || data.message || 'No se encontró la orden solicitada.');
-  }
-  return normalizeOrderFromApi(data.order ?? {});
-}
-
-async function updateOrderStatus(id, payload, { includeItems = false } = {}) {
-  const params = new URLSearchParams();
-  if (includeItems) params.set('with', 'items');
-  const res = await fetch(`/api/orders.php?id=${id}${params.toString() ? `&${params.toString()}` : ''}`, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify(payload)
-  });
-  const data = await res.json().catch(() => ({}));
-  if (!res.ok || data.error) {
-    throw new Error(data.error || data.message || 'No se pudo actualizar el pedido.');
-  }
-  return normalizeOrderFromApi(data.order ?? {});
+  hideOrderModalAlert();
 }
 
 function fillOrderModal(order, options = {}) {
   if (!orderModalTitle) return;
-  if (orderModalTitle) orderModalTitle.textContent = order.code ? `Orden ${order.code}` : `Orden #${order.id}`;
+  orderModalTitle.textContent = order.code ? `Orden ${order.code}` : `Orden #${order.id}`;
   if (orderModalIdInput) orderModalIdInput.value = order.id ?? '';
   if (orderModalForm) orderModalForm.dataset.orderId = order.id ?? '';
   if (orderModalCustomer) orderModalCustomer.textContent = order.customer?.name || 'Cliente sin nombre';
@@ -558,6 +495,33 @@ function fillOrderModal(order, options = {}) {
   if (options.focusField === 'delivery' && orderDeliveryNameInput) {
     setTimeout(() => orderDeliveryNameInput.focus(), 200);
   }
+}
+
+async function fetchOrderDetail(orderId) {
+  const params = new URLSearchParams({ id: orderId, with: 'items' });
+  const res = await fetch(`/api/orders.php?${params.toString()}`, {
+    headers: { 'Accept': 'application/json' },
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || data.error || !data.order) {
+    throw new Error(data.error || data.message || 'No se encontró la orden solicitada.');
+  }
+  return normalizeOrderFromApi(data.order ?? {});
+}
+
+async function updateOrderStatus(id, payload, { includeItems = false } = {}) {
+  const params = new URLSearchParams();
+  if (includeItems) params.set('with', 'items');
+  const res = await fetch(`/api/orders.php?id=${id}${params.toString() ? `&${params.toString()}` : ''}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || data.error) {
+    throw new Error(data.error || data.message || 'No se pudo actualizar el pedido.');
+  }
+  return normalizeOrderFromApi(data.order ?? {});
 }
 
 async function openOrderModal(orderId, options = {}) {
@@ -715,22 +679,20 @@ async function loadPedidos({ showLoader = true } = {}) {
     params.set('limit', '200');
 
     const res = await fetch(`/api/orders.php${params.toString() ? `?${params.toString()}` : ''}`, {
-      headers: { 'Accept': 'application/json' }
+      headers: { 'Accept': 'application/json' },
     });
     const data = await res.json().catch(() => ({}));
     if (!res.ok || data.error) {
-      throw new Error(data.error || data.message || 'No se pudieron cargar los pedidos.');
+      throw new Error(data.error || data.message || 'No se pudo cargar la lista de pedidos.');
     }
     const orders = Array.isArray(data.orders)
       ? data.orders
-      : Array.isArray(data.data)
-        ? data.data
-        : [];
+      : (Array.isArray(data.data) ? data.data : []);
     ordersState.list = orders.map(normalizeOrderFromApi);
     renderOrders();
   } catch (err) {
     console.error(err);
-    showOrdersAlert('danger', err.message || 'Error al cargar pedidos.');
+    showOrdersAlert('danger', err.message || 'No se pudo cargar la lista de pedidos.');
     if (!$ordersTbody.innerHTML.trim()) {
       $ordersTbody.innerHTML = `<tr><td colspan="8" class="text-center text-danger py-4">${escapeHtml(err.message || 'Error al cargar pedidos.')}</td></tr>`;
     }
@@ -748,17 +710,13 @@ ordersStatusCheckboxes.forEach(cb => {
   cb.addEventListener('change', () => {
     const selected = new Set();
     ordersStatusCheckboxes.forEach(box => {
-      if (box.checked) selected.add(normalizeStatusValue(box.value));
+      const value = normalizeStatusValue(box.value);
+      if (box.checked) {
+        selected.add(value);
+      }
     });
-    if (!selected.size) {
-      DEFAULT_ORDER_STATUSES.forEach(status => selected.add(status));
-      ordersStatusCheckboxes.forEach(box => {
-        box.checked = selected.has(normalizeStatusValue(box.value));
-      });
-    }
     ordersState.statusFilters = selected;
     renderOrders();
-    loadPedidos({ showLoader: true });
   });
 });
 
@@ -778,6 +736,11 @@ if (ordersClearBtn) {
       box.checked = ordersState.statusFilters.has(normalizeStatusValue(box.value));
     });
     renderOrders();
+  });
+}
+
+if (ordersReloadBtn) {
+  ordersReloadBtn.addEventListener('click', () => {
     loadPedidos({ showLoader: true });
   });
 }
@@ -797,177 +760,9 @@ if (orderModalCancelBtn) {
 
 if (orderModalElement) {
   orderModal.on('hidden.bs.modal', () => {
+    currentOrderDetail = null;
     resetOrderModal();
   });
 }
 
-if (ordersReloadBtn) {
-  ordersReloadBtn.addEventListener('click', () => {
-    loadPedidos({ showLoader: true });
-  });
-}
-
-async function loadProductos() {
-  const list = await apiFetch('/api/products'); // ✅ absoluto
-  $tbody.innerHTML = list.map(rowHTML).join('');
-}
-loadProductos();
-
-if (salesNavBtn) {
-  salesNavBtn.addEventListener('click', () => {
-    loadPedidos();
-  });
-}
-
-loadPedidos();
-
-/* ====== Crear ====== */
-document.querySelector('[data-target="#modalProducto"]').addEventListener('click', () => {
-  document.getElementById('modalTitle').textContent = 'Nuevo producto';
-  $frm.reset();
-  document.getElementById('p_id').value = '';
-  imgPreview.classList.add('d-none');
-  imgPreview.src = '';
-});
-
-/* ====== Guardar (crear/editar) ====== */
-$frm.addEventListener('submit', async (e) => {
-  e.preventDefault();
-  const id = document.getElementById('p_id').value.trim();
-
-  const payload = {
-    Codigo:    document.getElementById('p_codigo').value.trim(),
-    Nombre:    document.getElementById('p_nombre').value.trim(),
-    Precio:    Number(document.getElementById('p_precio').value || 0),
-    Stock:     Number(document.getElementById('p_stock').value || 0),
-    Activo:    Number(document.getElementById('p_activo').value || 1),
-    Categoria: document.getElementById('p_categoria').value.trim(),
-    Material:  document.getElementById('p_material').value.trim(),
-    ImagenUrl: document.getElementById('p_imagen').value.trim()
-  };
-
-  const opts = {
-    method: id ? 'PUT' : 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`
-    },
-    body: JSON.stringify(payload)
-  };
-
-  const path = id ? `/api/products/${id}` : '/api/products';
-  await apiFetch(path, opts); // ✅ absoluto + manejo de error
-  $modal.modal('hide');
-  await loadProductos();
-});
-
-/* ====== Editar / Borrar ====== */
-$tbody.addEventListener('click', async (e) => {
-  const tr = e.target.closest('tr');
-  if (!tr) return;
-  const id = tr.getAttribute('data-id');
-
-  if (e.target.classList.contains('btn-edit')) {
-    document.getElementById('modalTitle').textContent = 'Editar producto';
-    const p = await apiFetch(`/api/products/${id}`); // ✅
-
-    document.getElementById('p_id').value        = p.Id;
-    document.getElementById('p_codigo').value    = p.Codigo || '';
-    document.getElementById('p_nombre').value    = p.Nombre || '';
-    document.getElementById('p_precio').value    = p.Precio || 0;
-    document.getElementById('p_stock').value     = p.Stock || 0;
-    document.getElementById('p_activo').value    = Number(p.Activo ? 1 : 0);
-    document.getElementById('p_categoria').value = p.Categoria || '';
-    document.getElementById('p_material').value  = p.Material || '';
-    document.getElementById('p_imagen').value    = p.ImagenUrl || '';
-
-    if (p.ImagenUrl) {
-      imgPreview.src = p.ImagenUrl;
-      imgPreview.classList.remove('d-none');
-    } else {
-      imgPreview.classList.add('d-none');
-      imgPreview.src = '';
-    }
-
-    $modal.modal('show');
-  }
-
-  if (e.target.classList.contains('btn-del')) {
-    if (!confirm('¿Borrar este producto?')) return;
-    await apiFetch(`/api/products/${id}`, {
-      method: 'DELETE',
-      headers: { 'Authorization': `Bearer ${token}` }
-    }); // ✅
-    await loadProductos();
-  }
-});
-
-/* ====== Drag & Drop / Subida de imagen ====== */
-
-function openFilePicker() {
-  fileInput.click();
-}
-
-// click en el dropzone
-dropZone.addEventListener('click', openFilePicker);
-
-// resaltar cuando arrastras
-['dragenter', 'dragover'].forEach(ev =>
-  dropZone.addEventListener(ev, (e) => {
-    e.preventDefault(); e.stopPropagation();
-    dropZone.classList.add('dragover');
-  })
-);
-['dragleave', 'drop'].forEach(ev =>
-  dropZone.addEventListener(ev, (e) => {
-    e.preventDefault(); e.stopPropagation();
-    dropZone.classList.remove('dragover');
-  })
-);
-
-// soltar archivo
-dropZone.addEventListener('drop', (e) => {
-  const files = e.dataTransfer.files;
-  if (files && files[0]) handleFile(files[0]);
-});
-
-// file input manual
-fileInput.addEventListener('change', (e) => {
-  const file = e.target.files?.[0];
-  if (file) handleFile(file);
-});
-
-async function handleFile(file) {
-  const productId = document.getElementById('p_id').value.trim();
-  if (!productId) {
-    alert('Primero guarda el producto (para obtener su ID), luego vuelve a editar y sube la imagen.');
-    return;
-  }
-
-  // preview inmediata
-  const reader = new FileReader();
-  reader.onload = () => {
-    imgPreview.src = reader.result;
-    imgPreview.classList.remove('d-none');
-  };
-  reader.readAsDataURL(file);
-
-  try {
-    const formData = new FormData();
-    formData.append('file', file);
-
-    const res = await fetch(`${API_BASE}/api/products/${productId}/image`, { // ✅
-      method: 'POST',
-      headers: { 'Authorization': `Bearer ${token}` },
-      body: formData
-    });
-    const data = await res.json();
-    if (!res.ok) return alert(data.error || 'Error subiendo imagen');
-
-    // Actualiza el input de URL con la ruta subida
-    document.getElementById('p_imagen').value = data.url || '';
-  } catch (err) {
-    console.error(err);
-    alert('Error al subir imagen');
-  }
-}
+loadPedidos({ showLoader: true });

--- a/admin.html
+++ b/admin.html
@@ -433,6 +433,206 @@
       border-radius: 14px;
     }
 
+    /* Orders management */
+    .orders-toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      margin-bottom: 1rem;
+    }
+
+    .orders-status-filter {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 1rem;
+      font-weight: 600;
+      color: #1e3c72;
+    }
+
+    .orders-status-filter input[type="checkbox"] {
+      margin-right: 0.35rem;
+    }
+
+    .orders-filter-label {
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #6c7a92;
+    }
+
+    .orders-toolbar-actions {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .orders-toolbar .input-group {
+      min-width: 240px;
+    }
+
+    .orders-table td,
+    .orders-table th {
+      vertical-align: middle;
+    }
+
+    .orders-table tbody td {
+      vertical-align: top;
+    }
+
+    .status-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.35rem 0.65rem;
+      border-radius: 999px;
+      font-size: 0.75rem;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+    }
+
+    .badge-soft-warning {
+      background: rgba(255, 193, 7, 0.15);
+      color: #a36a00;
+    }
+
+    .badge-soft-info {
+      background: rgba(30, 144, 255, 0.12);
+      color: #1767aa;
+    }
+
+    .badge-soft-success {
+      background: rgba(40, 167, 69, 0.15);
+      color: #1d7a3c;
+    }
+
+    .badge-soft-danger {
+      background: rgba(220, 53, 69, 0.15);
+      color: #a01828;
+    }
+
+    .badge-soft-secondary {
+      background: rgba(108, 117, 125, 0.15);
+      color: #495057;
+    }
+
+    .order-delivery-chip,
+    .order-payment-chip {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.25rem 0.6rem;
+      border-radius: 14px;
+      font-size: 0.78rem;
+      font-weight: 600;
+      background: rgba(30, 60, 114, 0.08);
+      color: #1e3c72;
+    }
+
+    .order-payment-chip.pending {
+      background: rgba(255, 193, 7, 0.12);
+      color: #a36a00;
+    }
+
+    .order-payment-chip.confirmed {
+      background: rgba(40, 167, 69, 0.15);
+      color: #1d7a3c;
+    }
+
+    .order-delivery-chip.unassigned {
+      background: rgba(108, 117, 125, 0.12);
+      color: #495057;
+    }
+
+    .order-mini-meta {
+      display: block;
+      font-size: 0.78rem;
+      color: #6c7a92;
+    }
+
+    .order-meta-muted {
+      font-size: 0.78rem;
+      color: #97a1b7;
+    }
+
+    .orders-table .actions-column > .btn {
+      margin-left: 0.25rem;
+      margin-bottom: 0.35rem;
+    }
+
+    .orders-table .actions-column > .btn:first-child {
+      margin-left: 0;
+    }
+
+    .orders-table .actions-column {
+      white-space: nowrap;
+    }
+
+    .order-modal-box {
+      border: 1px solid rgba(30, 60, 114, 0.12);
+      border-radius: 12px;
+      padding: 1rem;
+      background: rgba(248, 249, 252, 0.65);
+      height: 100%;
+    }
+
+    .order-modal-timeline {
+      list-style: none;
+      padding-left: 0;
+    }
+
+    .order-modal-timeline li {
+      position: relative;
+      padding-left: 1.25rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .order-modal-timeline li::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0.3rem;
+      width: 0.5rem;
+      height: 0.5rem;
+      border-radius: 999px;
+      background: #1e3c72;
+    }
+
+    .order-modal-timeline li.text-muted::before {
+      background: #ced4da;
+    }
+
+    .modal .custom-control {
+      padding-left: 1.75rem;
+    }
+
+    .modal .custom-control-label::before,
+    .modal .custom-control-label::after {
+      left: -1.75rem;
+    }
+
+    @media (max-width: 576px) {
+      .orders-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .orders-toolbar .input-group {
+        width: 100%;
+      }
+
+      .orders-toolbar-actions {
+        width: 100%;
+        justify-content: space-between;
+      }
+
+      .orders-table .actions-column {
+        white-space: normal;
+      }
+    }
+
     .settings-panel .table-responsive::-webkit-scrollbar {
       height: 6px;
     }
@@ -720,19 +920,86 @@
         </section>
 
         <section class="content-section" id="section-sales">
-  <div class="section-card">
-    <div class="d-flex flex-wrap align-items-center mb-3">
-      <h2 class="section-title mb-0">Reportería</h2>
-      <span class="badge badge-pill badge-success ml-2">Ventas</span>
-    </div>
-    <iframe
-      src="reporteria.html"
-      class="dashboard-frame"
-      loading="lazy"
-      title="Dashboard de reportería"
-    ></iframe>
-  </div>
-</section>
+          <div class="section-card">
+            <div class="d-flex flex-wrap align-items-center mb-3">
+              <div>
+                <h2 class="section-title mb-1">Gestión de entregas</h2>
+                <p class="text-muted mb-0">Controla los pedidos pendientes, enviados y contra entrega.</p>
+              </div>
+              <div class="ml-auto d-flex align-items-center flex-wrap">
+                <button id="btnPedidosReload" class="btn btn-outline-primary btn-sm">Actualizar</button>
+              </div>
+            </div>
+
+            <div class="orders-toolbar">
+              <div class="orders-status-filter">
+                <span class="orders-filter-label">Mostrar:</span>
+                <label class="orders-status-option mb-0">
+                  <input type="checkbox" value="pendiente" data-order-status-filter checked>
+                  Pendientes
+                </label>
+                <label class="orders-status-option mb-0">
+                  <input type="checkbox" value="enviado" data-order-status-filter checked>
+                  Enviadas
+                </label>
+                <label class="orders-status-option mb-0">
+                  <input type="checkbox" value="pagado" data-order-status-filter>
+                  Pagadas
+                </label>
+                <label class="orders-status-option mb-0">
+                  <input type="checkbox" value="cancelado" data-order-status-filter>
+                  Canceladas
+                </label>
+              </div>
+              <div class="orders-toolbar-actions">
+                <div class="input-group input-group-sm">
+                  <div class="input-group-prepend">
+                    <span class="input-group-text"><i class="fas fa-search"></i></span>
+                  </div>
+                  <input id="ordersSearch" type="search" class="form-control" placeholder="Buscar cliente, orden o repartidor">
+                </div>
+                <button id="ordersClearFilters" type="button" class="btn btn-link btn-sm text-muted">Limpiar</button>
+              </div>
+            </div>
+
+            <div id="ordersAlert" class="alert alert-danger d-none"></div>
+
+            <div class="table-responsive shadow-sm rounded-lg">
+              <table id="tblPedidos" class="table table-hover orders-table mb-0">
+                <thead class="thead-light">
+                  <tr>
+                    <th>Orden</th>
+                    <th>Cliente</th>
+                    <th>Contacto</th>
+                    <th>Entrega</th>
+                    <th>Pago</th>
+                    <th>Total</th>
+                    <th>Actualización</th>
+                    <th class="text-right">Acciones</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td colspan="8" class="text-center text-muted py-4">Cargando pedidos...</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div class="section-card mt-4">
+            <div class="d-flex flex-wrap align-items-center mb-3">
+              <h2 class="section-title mb-0">Reportería</h2>
+              <span class="badge badge-pill badge-success ml-2">Ventas</span>
+            </div>
+            <iframe
+              src="reporteria.html"
+              class="dashboard-frame"
+              loading="lazy"
+              title="Dashboard de reportería"
+            ></iframe>
+          </div>
+        </section>
 
 
         <section class="content-section" id="section-revenue">
@@ -1058,6 +1325,118 @@
             </div>
           </div>
         </section>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal gestión de pedidos -->
+  <div class="modal fade" id="modalPedidoEstado" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+      <div class="modal-content">
+        <form id="frmPedidoEstado">
+          <div class="modal-header">
+            <h5 id="orderModalTitle" class="modal-title">Actualizar pedido</h5>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Cerrar">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+
+          <div class="modal-body">
+            <input type="hidden" id="orderModalId" />
+            <div id="orderModalAlert" class="alert alert-danger d-none"></div>
+
+            <div class="row">
+              <div class="col-md-6 mb-3">
+                <div class="order-modal-box">
+                  <h6 class="text-uppercase text-muted small mb-2">Cliente</h6>
+                  <p id="orderModalCustomer" class="mb-1 font-weight-semibold">—</p>
+                  <p id="orderModalContact" class="mb-1 text-muted">—</p>
+                  <p id="orderModalAddress" class="mb-0 text-muted">—</p>
+                </div>
+              </div>
+              <div class="col-md-6 mb-3">
+                <div class="order-modal-box">
+                  <h6 class="text-uppercase text-muted small mb-2">Pedido</h6>
+                  <p class="mb-1"><strong>Orden:</strong> <span id="orderModalCode">—</span></p>
+                  <p class="mb-1"><strong>Fecha:</strong> <span id="orderModalDate">—</span></p>
+                  <p class="mb-1"><strong>Método:</strong> <span id="orderModalPayment">—</span></p>
+                  <p class="mb-0"><strong>Total:</strong> <span id="orderModalTotal">—</span></p>
+                </div>
+              </div>
+            </div>
+
+            <div class="order-modal-box mb-3">
+              <h6 class="text-uppercase text-muted small mb-2">Seguimiento</h6>
+              <ul class="order-modal-timeline mb-0" id="orderModalTimeline">
+                <li class="text-muted">Cargando...</li>
+              </ul>
+            </div>
+
+            <div class="order-modal-box mb-3">
+              <h6 class="text-uppercase text-muted small mb-2">Productos</h6>
+              <div class="table-responsive">
+                <table class="table table-sm table-striped mb-0">
+                  <thead>
+                    <tr>
+                      <th>Producto</th>
+                      <th class="text-right">Cantidad</th>
+                      <th class="text-right">Precio</th>
+                      <th class="text-right">Subtotal</th>
+                    </tr>
+                  </thead>
+                  <tbody id="orderModalItemsBody">
+                    <tr>
+                      <td colspan="4" class="text-center text-muted py-3">Cargando productos...</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <div class="form-row">
+              <div class="form-group col-md-6">
+                <label for="orderStatusSelect">Cambiar estado</label>
+                <select id="orderStatusSelect" class="form-control" required>
+                  <option value="pendiente">Pendiente</option>
+                  <option value="enviado">Enviado</option>
+                  <option value="pagado">Pagado</option>
+                  <option value="cancelado">Cancelado</option>
+                </select>
+              </div>
+              <div class="form-group col-md-6">
+                <label for="orderDeliveryName" class="d-flex justify-content-between">
+                  <span>Repartidor asignado</span>
+                  <small class="text-muted">Obligatorio para enviar</small>
+                </label>
+                <input id="orderDeliveryName" type="text" class="form-control" placeholder="Nombre del repartidor" />
+              </div>
+            </div>
+
+            <div class="form-row">
+              <div class="form-group col-md-6">
+                <label for="orderDeliveryContact">Contacto del repartidor</label>
+                <input id="orderDeliveryContact" type="text" class="form-control" placeholder="Teléfono o identificación" />
+              </div>
+              <div class="form-group col-md-6 d-flex align-items-center">
+                <div class="custom-control custom-checkbox">
+                  <input type="checkbox" class="custom-control-input" id="orderPaymentConfirmed" />
+                  <label class="custom-control-label" for="orderPaymentConfirmed">Pago contra entrega confirmado</label>
+                </div>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label for="orderNotes">Notas internas</label>
+              <textarea id="orderNotes" class="form-control" rows="2" placeholder="Comentarios o instrucciones adicionales"></textarea>
+            </div>
+          </div>
+
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-danger mr-auto" id="orderModalCancelBtn">Cancelar pedido</button>
+            <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">Cerrar</button>
+            <button type="submit" class="btn btn-primary" id="orderModalSubmitBtn">Guardar cambios</button>
+          </div>
+        </form>
       </div>
     </div>
   </div>

--- a/api/orders.php
+++ b/api/orders.php
@@ -1,0 +1,842 @@
+<?php
+declare(strict_types=1);
+
+header('Content-Type: application/json; charset=utf-8');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, PATCH, PUT, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With');
+header('Access-Control-Max-Age: 86400');
+header('Vary: Origin');
+
+require __DIR__ . '/db.php';
+
+const ALLOWED_ORDER_STATUSES = ['pendiente', 'enviado', 'pagado', 'cancelado'];
+
+function respondJson(int $status, array $payload = []): void
+{
+    http_response_code($status);
+    if ($status === 204) {
+        exit;
+    }
+    echo json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+function respondError(int $status, string $message, array $extra = []): void
+{
+    $payload = array_merge(['error' => $message], $extra);
+    respondJson($status, $payload);
+}
+
+function readJsonInput(): array
+{
+    $raw = file_get_contents('php://input');
+    if ($raw === false || $raw === '') {
+        return [];
+    }
+    $data = json_decode($raw, true);
+    if (json_last_error() !== JSON_ERROR_NONE || !is_array($data)) {
+        return [];
+    }
+    return $data;
+}
+
+function tableExists(PDO $pdo, string $table): bool
+{
+    $stmt = $pdo->prepare(
+        'SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :table'
+    );
+    $stmt->execute([':table' => $table]);
+    return (int) $stmt->fetchColumn() > 0;
+}
+
+function columnExists(PDO $pdo, string $table, string $column): bool
+{
+    $stmt = $pdo->prepare(
+        'SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :table AND COLUMN_NAME = :column'
+    );
+    $stmt->execute([
+        ':table' => $table,
+        ':column' => $column,
+    ]);
+    return (int) $stmt->fetchColumn() > 0;
+}
+
+function detectTable(PDO $pdo, array $candidates): ?string
+{
+    foreach ($candidates as $candidate) {
+        if (tableExists($pdo, $candidate)) {
+            return $candidate;
+        }
+    }
+    return null;
+}
+
+function detectColumn(PDO $pdo, string $table, array $candidates): ?string
+{
+    foreach ($candidates as $candidate) {
+        if (columnExists($pdo, $table, $candidate)) {
+            return $candidate;
+        }
+    }
+    return null;
+}
+
+function ensureDeliveryTable(PDO $pdo, string $orderTable, string $orderPk): void
+{
+    $pdo->exec(
+        'CREATE TABLE IF NOT EXISTS orden_entrega (
+            orden_id INT NOT NULL,
+            estado VARCHAR(20) NOT NULL DEFAULT "pendiente",
+            repartidor_id INT NULL,
+            repartidor_nombre VARCHAR(120) NULL,
+            repartidor_contacto VARCHAR(120) NULL,
+            notas TEXT NULL,
+            pago_confirmado TINYINT(1) NOT NULL DEFAULT 0,
+            fecha_asignacion DATETIME NULL,
+            fecha_envio DATETIME NULL,
+            fecha_pago DATETIME NULL,
+            fecha_cancelacion DATETIME NULL,
+            actualizado_en TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            actualizado_por INT NULL,
+            PRIMARY KEY (orden_id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'
+    );
+
+    if (!columnExists($pdo, 'orden_entrega', 'repartidor_contacto')) {
+        $pdo->exec('ALTER TABLE orden_entrega ADD COLUMN repartidor_contacto VARCHAR(120) NULL AFTER repartidor_nombre');
+    }
+    if (!columnExists($pdo, 'orden_entrega', 'notas')) {
+        $pdo->exec('ALTER TABLE orden_entrega ADD COLUMN notas TEXT NULL AFTER repartidor_contacto');
+    }
+    if (!columnExists($pdo, 'orden_entrega', 'pago_confirmado')) {
+        $pdo->exec('ALTER TABLE orden_entrega ADD COLUMN pago_confirmado TINYINT(1) NOT NULL DEFAULT 0 AFTER notas');
+    }
+    foreach (['fecha_asignacion', 'fecha_envio', 'fecha_pago', 'fecha_cancelacion'] as $column) {
+        if (!columnExists($pdo, 'orden_entrega', $column)) {
+            $pdo->exec("ALTER TABLE orden_entrega ADD COLUMN {$column} DATETIME NULL AFTER pago_confirmado");
+        }
+    }
+    if (!columnExists($pdo, 'orden_entrega', 'actualizado_en')) {
+        $pdo->exec(
+            'ALTER TABLE orden_entrega ADD COLUMN actualizado_en TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER fecha_cancelacion'
+        );
+    }
+    if (!columnExists($pdo, 'orden_entrega', 'actualizado_por')) {
+        $pdo->exec('ALTER TABLE orden_entrega ADD COLUMN actualizado_por INT NULL AFTER actualizado_en');
+    }
+
+    $stmt = $pdo->prepare(
+        "SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+         WHERE TABLE_SCHEMA = DATABASE()
+           AND TABLE_NAME = 'orden_entrega'
+           AND REFERENCED_TABLE_NAME = :refTable"
+    );
+    $stmt->execute([':refTable' => $orderTable]);
+    $hasForeignKey = (bool) $stmt->fetchColumn();
+
+    if (!$hasForeignKey) {
+        try {
+            $constraint = 'fk_orden_entrega_' . preg_replace('/[^a-z0-9_]/i', '', $orderTable);
+            $pdo->exec(
+                sprintf(
+                    'ALTER TABLE orden_entrega
+                     ADD CONSTRAINT %s
+                     FOREIGN KEY (orden_id) REFERENCES %s(%s)
+                     ON DELETE CASCADE ON UPDATE CASCADE',
+                    $constraint,
+                    $orderTable,
+                    $orderPk
+                )
+            );
+        } catch (Throwable $e) {
+            // Ignorar si ya existe con otro nombre o no se puede crear la relación.
+        }
+    }
+}
+
+function normalizeStatus(?string $status): string
+{
+    $status = $status === null ? '' : trim(mb_strtolower($status));
+    if ($status === '') {
+        return 'pendiente';
+    }
+    $map = [
+        'pending' => 'pendiente',
+        'procesando' => 'pendiente',
+        'processing' => 'pendiente',
+        'nuevo' => 'pendiente',
+        'new' => 'pendiente',
+        'enviada' => 'enviado',
+        'despachado' => 'enviado',
+        'despachada' => 'enviado',
+        'shipped' => 'enviado',
+        'delivery' => 'enviado',
+        'pagada' => 'pagado',
+        'paid' => 'pagado',
+        'completado' => 'pagado',
+        'completada' => 'pagado',
+        'completed' => 'pagado',
+        'cancelada' => 'cancelado',
+        'cancelled' => 'cancelado',
+        'anulado' => 'cancelado',
+        'anulada' => 'cancelado',
+        'void' => 'cancelado',
+    ];
+    return $map[$status] ?? $status;
+}
+
+function statusLabel(string $status): string
+{
+    return match ($status) {
+        'pendiente' => 'Pendiente',
+        'enviado' => 'Enviado',
+        'pagado' => 'Pagado',
+        'cancelado' => 'Cancelado',
+        default => ucfirst($status),
+    };
+}
+
+function detectOrdersSchema(PDO $pdo): array
+{
+    $orderTable = detectTable($pdo, ['orden', 'ordenes', 'pedido', 'pedidos', 'venta', 'ventas', 'orders', 'order']);
+    if (!$orderTable) {
+        throw new RuntimeException('No se encontró la tabla de órdenes en la base de datos.');
+    }
+
+    $orderId = detectColumn($pdo, $orderTable, ['orden_id', 'id', 'pedido_id', 'venta_id', 'order_id']);
+    if (!$orderId) {
+        throw new RuntimeException('No se encontró la columna identificadora de la orden.');
+    }
+
+    $schema = [
+        'order_table' => $orderTable,
+        'order_id' => $orderId,
+        'order_code' => detectColumn($pdo, $orderTable, ['codigo', 'codigo_orden', 'numero', 'numero_orden', 'order_number', 'referencia']),
+        'order_status' => detectColumn($pdo, $orderTable, ['estado', 'estatus', 'status']),
+        'order_total' => detectColumn($pdo, $orderTable, ['total', 'total_pedido', 'monto_total', 'total_final', 'gran_total']),
+        'order_payment_method' => detectColumn($pdo, $orderTable, ['metodo_pago', 'forma_pago', 'payment_method', 'metodo', 'metodo_de_pago']),
+        'order_payment_reference' => detectColumn($pdo, $orderTable, ['referencia_pago', 'referencia', 'no_transaccion', 'numero_referencia', 'transaccion']),
+        'order_coupon' => detectColumn($pdo, $orderTable, ['cupon_codigo', 'cupon', 'coupon_code', 'codigo_descuento']),
+        'order_customer_name' => detectColumn($pdo, $orderTable, ['nombre_cliente', 'cliente', 'cliente_nombre', 'customer_name', 'customer']),
+        'order_customer_email' => detectColumn($pdo, $orderTable, ['correo_cliente', 'email_cliente', 'email', 'correo', 'customer_email']),
+        'order_customer_phone' => detectColumn($pdo, $orderTable, ['telefono_cliente', 'telefono', 'telefono_contacto', 'phone', 'customer_phone']),
+        'order_customer_address' => detectColumn($pdo, $orderTable, ['direccion_envio', 'direccion', 'direccion_entrega', 'shipping_address', 'address']),
+        'order_created_at' => detectColumn($pdo, $orderTable, ['fecha', 'fecha_creacion', 'fecha_registro', 'created_at', 'creado_en']),
+        'order_updated_at' => detectColumn($pdo, $orderTable, ['updated_at', 'fecha_actualizacion', 'actualizado_en', 'fecha_modificacion']),
+    ];
+
+    $detailTable = detectTable($pdo, ['orden_detalle', 'orden_detalles', 'detalle_orden', 'detalles_orden', 'order_items', 'pedido_detalle', 'detalle_pedido', 'venta_detalle', 'detalle_venta']);
+    $schema['detail_table'] = $detailTable;
+    if ($detailTable) {
+        $schema['detail_order_fk'] = detectColumn($pdo, $detailTable, ['orden_id', 'order_id', 'pedido_id', 'venta_id']);
+        $schema['detail_product_fk'] = detectColumn($pdo, $detailTable, ['producto_id', 'product_id', 'articulo_id', 'item_id']);
+        $schema['detail_quantity'] = detectColumn($pdo, $detailTable, ['cantidad', 'qty', 'quantity', 'unidades', 'units']);
+        $schema['detail_unit_price'] = detectColumn($pdo, $detailTable, ['precio_unitario', 'precio', 'price', 'unit_price', 'valor_unitario']);
+        $schema['detail_total_line'] = detectColumn($pdo, $detailTable, ['total_linea', 'total_line', 'subtotal', 'monto']);
+    } else {
+        $schema['detail_order_fk'] = $schema['detail_product_fk'] = $schema['detail_quantity'] = $schema['detail_unit_price'] = $schema['detail_total_line'] = null;
+    }
+
+    $productTable = detectTable($pdo, ['producto', 'productos', 'articulo', 'articulos', 'product', 'products']);
+    $schema['product_table'] = $productTable;
+    if ($productTable) {
+        $schema['product_id'] = detectColumn($pdo, $productTable, ['producto_id', 'id', 'articulo_id', 'product_id']);
+        $schema['product_name'] = detectColumn($pdo, $productTable, ['nombre', 'descripcion', 'name', 'titulo']);
+        $schema['product_stock'] = detectColumn($pdo, $productTable, ['stock', 'existencia', 'existencias', 'cantidad', 'cantidad_disponible']);
+    } else {
+        $schema['product_id'] = $schema['product_name'] = $schema['product_stock'] = null;
+    }
+
+    return $schema;
+}
+
+function sqlStatusExpression(array $schema): string
+{
+    $parts = ["NULLIF(oe.estado,'')"];
+    if (!empty($schema['order_status'])) {
+        $parts[] = "NULLIF(o." . $schema['order_status'] . ",'')";
+    }
+    $parts[] = "'pendiente'";
+    return 'LOWER(COALESCE(' . implode(', ', $parts) . '))';
+}
+
+function formatDateValue(?string $value): ?string
+{
+    if ($value === null || $value === '') {
+        return null;
+    }
+    return substr($value, 0, 19);
+}
+
+function formatOrderRow(array $row): array
+{
+    $status = normalizeStatus($row['estado'] ?? $row['estado_gestion'] ?? '');
+    if (!in_array($status, ALLOWED_ORDER_STATUSES, true)) {
+        $status = normalizeStatus($status);
+    }
+
+    $total = null;
+    if (isset($row['total'])) {
+        $numeric = is_numeric($row['total']) ? (float) $row['total'] : null;
+        if ($numeric !== null) {
+            $total = $numeric;
+        }
+    }
+
+    return [
+        'id' => isset($row['id']) ? (int) $row['id'] : null,
+        'code' => $row['codigo'] ?? null,
+        'status' => $status,
+        'status_label' => statusLabel($status),
+        'total' => $total,
+        'payment_method' => $row['metodo_pago'] ?? null,
+        'payment_reference' => $row['referencia_pago'] ?? null,
+        'coupon_code' => $row['cupon_codigo'] ?? null,
+        'customer' => [
+            'name' => $row['cliente'] ?? null,
+            'email' => $row['cliente_email'] ?? null,
+            'phone' => $row['cliente_telefono'] ?? null,
+            'address' => $row['cliente_direccion'] ?? null,
+        ],
+        'delivery' => [
+            'person' => [
+                'id' => isset($row['repartidor_id']) ? (int) $row['repartidor_id'] : null,
+                'name' => $row['repartidor_nombre'] ?? null,
+                'contact' => $row['repartidor_contacto'] ?? null,
+            ],
+            'payment_confirmed' => (bool) ($row['pago_confirmado'] ?? false),
+            'notes' => $row['notas'] ?? null,
+            'assigned_at' => formatDateValue($row['fecha_asignacion'] ?? null),
+            'shipped_at' => formatDateValue($row['fecha_envio'] ?? null),
+            'paid_at' => formatDateValue($row['fecha_pago'] ?? null),
+            'canceled_at' => formatDateValue($row['fecha_cancelacion'] ?? null),
+            'updated_at' => formatDateValue($row['gestion_actualizado_en'] ?? null),
+        ],
+        'created_at' => formatDateValue($row['creado_en'] ?? null),
+        'updated_at' => formatDateValue($row['actualizado_en'] ?? null),
+    ];
+}
+
+function fetchOrdersList(PDO $pdo, array $schema, array $filters = []): array
+{
+    $statusExpr = sqlStatusExpression($schema);
+    $select = [
+        'o.' . $schema['order_id'] . ' AS id',
+        $statusExpr . ' AS estado',
+        'oe.estado AS estado_gestion',
+        'oe.pago_confirmado AS pago_confirmado',
+        'oe.repartidor_nombre',
+        'oe.repartidor_contacto',
+        'oe.repartidor_id',
+        'oe.notas',
+        'oe.fecha_asignacion',
+        'oe.fecha_envio',
+        'oe.fecha_pago',
+        'oe.fecha_cancelacion',
+        'oe.actualizado_en AS gestion_actualizado_en',
+    ];
+
+    if (!empty($schema['order_code'])) {
+        $select[] = 'o.' . $schema['order_code'] . ' AS codigo';
+    }
+    if (!empty($schema['order_total'])) {
+        $select[] = 'o.' . $schema['order_total'] . ' AS total';
+    } else {
+        $select[] = 'NULL AS total';
+    }
+    if (!empty($schema['order_payment_method'])) {
+        $select[] = 'o.' . $schema['order_payment_method'] . ' AS metodo_pago';
+    }
+    if (!empty($schema['order_payment_reference'])) {
+        $select[] = 'o.' . $schema['order_payment_reference'] . ' AS referencia_pago';
+    }
+    if (!empty($schema['order_coupon'])) {
+        $select[] = 'o.' . $schema['order_coupon'] . ' AS cupon_codigo';
+    }
+    if (!empty($schema['order_customer_name'])) {
+        $select[] = 'o.' . $schema['order_customer_name'] . ' AS cliente';
+    }
+    if (!empty($schema['order_customer_email'])) {
+        $select[] = 'o.' . $schema['order_customer_email'] . ' AS cliente_email';
+    }
+    if (!empty($schema['order_customer_phone'])) {
+        $select[] = 'o.' . $schema['order_customer_phone'] . ' AS cliente_telefono';
+    }
+    if (!empty($schema['order_customer_address'])) {
+        $select[] = 'o.' . $schema['order_customer_address'] . ' AS cliente_direccion';
+    }
+    if (!empty($schema['order_created_at'])) {
+        $select[] = 'o.' . $schema['order_created_at'] . ' AS creado_en';
+    } else {
+        $select[] = 'NULL AS creado_en';
+    }
+    if (!empty($schema['order_updated_at'])) {
+        $select[] = 'o.' . $schema['order_updated_at'] . ' AS actualizado_en';
+    } else {
+        $select[] = 'NULL AS actualizado_en';
+    }
+
+    $sql = 'SELECT ' . implode("
+       ", $select) . "
+"
+         . 'FROM ' . $schema['order_table'] . ' o
+'
+         . 'LEFT JOIN orden_entrega oe ON oe.orden_id = o.' . $schema['order_id'] . "
+";
+
+    $where = [];
+    $params = [];
+
+    if (!empty($filters['statuses']) && is_array($filters['statuses'])) {
+        $statuses = array_values(array_filter(array_map('normalizeStatus', $filters['statuses'])));
+        if ($statuses) {
+            $placeholders = [];
+            foreach ($statuses as $i => $value) {
+                $ph = ':status' . $i;
+                $placeholders[] = $ph;
+                $params[$ph] = $value;
+            }
+            $where[] = $statusExpr . ' IN (' . implode(', ', $placeholders) . ')';
+        }
+    }
+
+    $search = trim((string) ($filters['search'] ?? ''));
+    if ($search !== '') {
+        $like = '%' . $search . '%';
+        $conditions = [];
+        if (!empty($schema['order_code'])) {
+            $conditions[] = 'o.' . $schema['order_code'] . ' LIKE :search';
+        }
+        if (!empty($schema['order_customer_name'])) {
+            $conditions[] = 'o.' . $schema['order_customer_name'] . ' LIKE :search';
+        }
+        if (!empty($schema['order_customer_phone'])) {
+            $conditions[] = 'o.' . $schema['order_customer_phone'] . ' LIKE :search';
+        }
+        if (!empty($schema['order_customer_address'])) {
+            $conditions[] = 'o.' . $schema['order_customer_address'] . ' LIKE :search';
+        }
+        $conditions[] = 'oe.repartidor_nombre LIKE :search';
+        if ($conditions) {
+            $where[] = '(' . implode(' OR ', $conditions) . ')';
+            $params[':search'] = $like;
+        }
+    }
+
+    if ($where) {
+        $sql .= 'WHERE ' . implode(' AND ', $where) . "
+";
+    }
+
+    $orderBy = !empty($schema['order_updated_at']) ? 'o.' . $schema['order_updated_at']
+        : (!empty($schema['order_created_at']) ? 'o.' . $schema['order_created_at'] : 'o.' . $schema['order_id']);
+    $sql .= 'ORDER BY ' . $orderBy . ' DESC
+';
+
+    $limit = isset($filters['limit']) ? (int) $filters['limit'] : 200;
+    if ($limit > 0) {
+        $sql .= 'LIMIT ' . min($limit, 500);
+    }
+
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
+    $rows = $stmt->fetchAll();
+
+    return array_map(static fn(array $row): array => formatOrderRow($row), $rows);
+}
+
+function fetchOrderRow(PDO $pdo, array $schema, int $id): ?array
+{
+    $statusExpr = sqlStatusExpression($schema);
+    $select = [
+        'o.' . $schema['order_id'] . ' AS id',
+        $statusExpr . ' AS estado',
+        'oe.estado AS estado_gestion',
+        'oe.pago_confirmado AS pago_confirmado',
+        'oe.repartidor_nombre',
+        'oe.repartidor_contacto',
+        'oe.repartidor_id',
+        'oe.notas',
+        'oe.fecha_asignacion',
+        'oe.fecha_envio',
+        'oe.fecha_pago',
+        'oe.fecha_cancelacion',
+        'oe.actualizado_en AS gestion_actualizado_en',
+    ];
+
+    if (!empty($schema['order_code'])) {
+        $select[] = 'o.' . $schema['order_code'] . ' AS codigo';
+    }
+    if (!empty($schema['order_total'])) {
+        $select[] = 'o.' . $schema['order_total'] . ' AS total';
+    }
+    if (!empty($schema['order_payment_method'])) {
+        $select[] = 'o.' . $schema['order_payment_method'] . ' AS metodo_pago';
+    }
+    if (!empty($schema['order_payment_reference'])) {
+        $select[] = 'o.' . $schema['order_payment_reference'] . ' AS referencia_pago';
+    }
+    if (!empty($schema['order_coupon'])) {
+        $select[] = 'o.' . $schema['order_coupon'] . ' AS cupon_codigo';
+    }
+    if (!empty($schema['order_customer_name'])) {
+        $select[] = 'o.' . $schema['order_customer_name'] . ' AS cliente';
+    }
+    if (!empty($schema['order_customer_email'])) {
+        $select[] = 'o.' . $schema['order_customer_email'] . ' AS cliente_email';
+    }
+    if (!empty($schema['order_customer_phone'])) {
+        $select[] = 'o.' . $schema['order_customer_phone'] . ' AS cliente_telefono';
+    }
+    if (!empty($schema['order_customer_address'])) {
+        $select[] = 'o.' . $schema['order_customer_address'] . ' AS cliente_direccion';
+    }
+    if (!empty($schema['order_created_at'])) {
+        $select[] = 'o.' . $schema['order_created_at'] . ' AS creado_en';
+    }
+    if (!empty($schema['order_updated_at'])) {
+        $select[] = 'o.' . $schema['order_updated_at'] . ' AS actualizado_en';
+    }
+
+    $sql = 'SELECT ' . implode("
+       ", $select) . "
+"
+         . 'FROM ' . $schema['order_table'] . ' o
+'
+         . 'LEFT JOIN orden_entrega oe ON oe.orden_id = o.' . $schema['order_id'] . "
+"
+         . 'WHERE o.' . $schema['order_id'] . ' = :id
+'
+         . 'LIMIT 1';
+
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([':id' => $id]);
+    $row = $stmt->fetch();
+    if (!$row) {
+        return null;
+    }
+    return formatOrderRow($row);
+}
+
+function fetchOrderItems(PDO $pdo, array $schema, int $orderId): array
+{
+    if (empty($schema['detail_table']) || empty($schema['detail_order_fk'])) {
+        return [];
+    }
+
+    $columns = [
+        'd.' . $schema['detail_product_fk'] . ' AS product_id',
+    ];
+    if (!empty($schema['detail_quantity'])) {
+        $columns[] = 'd.' . $schema['detail_quantity'] . ' AS quantity';
+    }
+    if (!empty($schema['detail_unit_price'])) {
+        $columns[] = 'd.' . $schema['detail_unit_price'] . ' AS unit_price';
+    }
+    if (!empty($schema['detail_total_line'])) {
+        $columns[] = 'd.' . $schema['detail_total_line'] . ' AS line_total';
+    }
+
+    if (!empty($schema['product_table']) && !empty($schema['product_id']) && !empty($schema['product_name'])) {
+        $columns[] = 'p.' . $schema['product_name'] . ' AS product_name';
+        $join = 'LEFT JOIN ' . $schema['product_table'] . ' p ON p.' . $schema['product_id'] . ' = d.' . $schema['detail_product_fk'];
+    } else {
+        $columns[] = 'NULL AS product_name';
+        $join = '';
+    }
+
+    $sql = 'SELECT ' . implode(', ', $columns) . "
+"
+         . 'FROM ' . $schema['detail_table'] . ' d
+'
+         . $join . "
+"
+         . 'WHERE d.' . $schema['detail_order_fk'] . ' = :id
+'
+         . 'ORDER BY d.' . $schema['detail_product_fk'];
+
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([':id' => $orderId]);
+    $rows = $stmt->fetchAll();
+
+    return array_map(static function (array $row): array {
+        $quantity = isset($row['quantity']) && is_numeric($row['quantity']) ? (float) $row['quantity'] : null;
+        $unitPrice = isset($row['unit_price']) && is_numeric($row['unit_price']) ? (float) $row['unit_price'] : null;
+        $lineTotal = isset($row['line_total']) && is_numeric($row['line_total']) ? (float) $row['line_total'] : null;
+
+        if ($lineTotal === null && $quantity !== null && $unitPrice !== null) {
+            $lineTotal = $quantity * $unitPrice;
+        }
+
+        return [
+            'product_id' => isset($row['product_id']) ? (int) $row['product_id'] : null,
+            'product_name' => $row['product_name'] ?? null,
+            'quantity' => $quantity,
+            'unit_price' => $unitPrice,
+            'line_total' => $lineTotal,
+        ];
+    }, $rows);
+}
+
+function restockOrderItems(PDO $pdo, array $schema, int $orderId): void
+{
+    if (empty($schema['detail_table']) || empty($schema['product_table']) || empty($schema['detail_product_fk']) || empty($schema['product_stock']) || empty($schema['detail_quantity'])) {
+        return;
+    }
+
+    $sql = 'SELECT ' . $schema['detail_product_fk'] . ' AS product_id, ' . $schema['detail_quantity'] . ' AS quantity
+            FROM ' . $schema['detail_table'] . '
+            WHERE ' . $schema['detail_order_fk'] . ' = :id';
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([':id' => $orderId]);
+    $items = $stmt->fetchAll();
+
+    foreach ($items as $item) {
+        if (!isset($item['product_id']) || !isset($item['quantity'])) {
+            continue;
+        }
+        $qty = (float) $item['quantity'];
+        if ($qty <= 0) {
+            continue;
+        }
+        $update = $pdo->prepare(
+            'UPDATE ' . $schema['product_table'] . '
+             SET ' . $schema['product_stock'] . ' = ' . $schema['product_stock'] . ' + :qty
+             WHERE ' . $schema['product_id'] . ' = :pid'
+        );
+        $update->execute([
+            ':qty' => $qty,
+            ':pid' => $item['product_id'],
+        ]);
+    }
+}
+
+function extractStatusesFromQuery($input): array
+{
+    $values = [];
+    if (is_array($input)) {
+        foreach ($input as $entry) {
+            $values = array_merge($values, extractStatusesFromQuery($entry));
+        }
+        return array_values(array_unique($values));
+    }
+    if ($input === null || $input === '') {
+        return [];
+    }
+    $parts = preg_split('/[|,]/', (string) $input);
+    $statuses = [];
+    foreach ($parts as $part) {
+        $normalized = normalizeStatus($part);
+        if ($normalized !== '' && !in_array($normalized, $statuses, true)) {
+            $statuses[] = $normalized;
+        }
+    }
+    return $statuses;
+}
+
+function updateOrder(PDO $pdo, array $schema, int $id, array $payload): array
+{
+    $order = fetchOrderRow($pdo, $schema, $id);
+    if (!$order) {
+        throw new RuntimeException('No se encontró la orden solicitada.');
+    }
+
+    $previousStatus = normalizeStatus($order['status']);
+    if ($previousStatus === 'cancelado' && (!isset($payload['status']) || normalizeStatus($payload['status']) !== 'cancelado')) {
+        throw new InvalidArgumentException('La orden cancelada no puede cambiarse a otro estado.');
+    }
+
+    $newStatus = array_key_exists('status', $payload) ? normalizeStatus((string) $payload['status']) : $previousStatus;
+    if (!in_array($newStatus, ALLOWED_ORDER_STATUSES, true)) {
+        throw new InvalidArgumentException('Estado de orden no válido.');
+    }
+
+    $deliveryName = isset($payload['delivery_person']) ? trim((string) $payload['delivery_person']) : ($order['delivery']['person']['name'] ?? '');
+    $deliveryContact = isset($payload['delivery_contact']) ? trim((string) $payload['delivery_contact']) : ($order['delivery']['person']['contact'] ?? null);
+    $deliveryId = isset($payload['delivery_person_id']) && $payload['delivery_person_id'] !== ''
+        ? (int) $payload['delivery_person_id']
+        : ($order['delivery']['person']['id'] ?? null);
+
+    if ($newStatus === 'enviado' && $deliveryName === '') {
+        throw new InvalidArgumentException('Debes asignar un repartidor antes de marcar la orden como enviada.');
+    }
+
+    $paymentConfirmed = array_key_exists('payment_confirmed', $payload)
+        ? (bool) $payload['payment_confirmed']
+        : (bool) ($order['delivery']['payment_confirmed'] ?? false);
+    if ($newStatus === 'pagado') {
+        $paymentConfirmed = true;
+    }
+
+    $notes = isset($payload['notes']) ? trim((string) $payload['notes']) : ($order['delivery']['notes'] ?? null);
+
+    $previouslyPaid = (bool) ($order['delivery']['payment_confirmed'] ?? false);
+
+    $now = (new DateTimeImmutable('now'))->format('Y-m-d H:i:s');
+
+    $assignedAt = $order['delivery']['assigned_at'] ?? null;
+    if ($deliveryName !== '') {
+        if (!$assignedAt || $deliveryName !== ($order['delivery']['person']['name'] ?? null)) {
+            $assignedAt = $now;
+        }
+    } else {
+        $assignedAt = null;
+    }
+
+    $shippedAt = $order['delivery']['shipped_at'] ?? null;
+    if ($newStatus === 'enviado' && $previousStatus !== 'enviado') {
+        $shippedAt = $now;
+    }
+
+    $paidAt = $order['delivery']['paid_at'] ?? null;
+    if (($newStatus === 'pagado' && $previousStatus !== 'pagado') || (!$previouslyPaid && $paymentConfirmed)) {
+        $paidAt = $now;
+    }
+
+    $canceledAt = $order['delivery']['canceled_at'] ?? null;
+    $shouldRestock = false;
+    if ($newStatus === 'cancelado' && $previousStatus !== 'cancelado') {
+        $canceledAt = $now;
+        $shouldRestock = true;
+    }
+
+    $pdo->beginTransaction();
+    try {
+        if (!empty($schema['order_status'])) {
+            $stmt = $pdo->prepare(
+                'UPDATE ' . $schema['order_table'] . '
+                 SET ' . $schema['order_status'] . ' = :status
+                 WHERE ' . $schema['order_id'] . ' = :id'
+            );
+            $stmt->execute([
+                ':status' => $newStatus,
+                ':id' => $id,
+            ]);
+        }
+
+        $insert = $pdo->prepare(
+            'INSERT INTO orden_entrega (
+                orden_id, estado, repartidor_id, repartidor_nombre, repartidor_contacto, notas, pago_confirmado,
+                fecha_asignacion, fecha_envio, fecha_pago, fecha_cancelacion, actualizado_por
+            ) VALUES (
+                :orden_id, :estado, :repartidor_id, :repartidor_nombre, :repartidor_contacto, :notas, :pago_confirmado,
+                :fecha_asignacion, :fecha_envio, :fecha_pago, :fecha_cancelacion, :actualizado_por
+            )
+            ON DUPLICATE KEY UPDATE
+                estado = VALUES(estado),
+                repartidor_id = VALUES(repartidor_id),
+                repartidor_nombre = VALUES(repartidor_nombre),
+                repartidor_contacto = VALUES(repartidor_contacto),
+                notas = VALUES(notas),
+                pago_confirmado = VALUES(pago_confirmado),
+                fecha_asignacion = COALESCE(VALUES(fecha_asignacion), fecha_asignacion),
+                fecha_envio = COALESCE(VALUES(fecha_envio), fecha_envio),
+                fecha_pago = COALESCE(VALUES(fecha_pago), fecha_pago),
+                fecha_cancelacion = COALESCE(VALUES(fecha_cancelacion), fecha_cancelacion),
+                actualizado_por = VALUES(actualizado_por)'
+        );
+        $insert->execute([
+            ':orden_id' => $id,
+            ':estado' => $newStatus,
+            ':repartidor_id' => $deliveryId,
+            ':repartidor_nombre' => $deliveryName !== '' ? $deliveryName : null,
+            ':repartidor_contacto' => $deliveryContact !== '' ? $deliveryContact : null,
+            ':notas' => $notes !== '' ? $notes : null,
+            ':pago_confirmado' => $paymentConfirmed ? 1 : 0,
+            ':fecha_asignacion' => $assignedAt,
+            ':fecha_envio' => $shippedAt,
+            ':fecha_pago' => $paidAt,
+            ':fecha_cancelacion' => $canceledAt,
+            ':actualizado_por' => null,
+        ]);
+
+        if ($shouldRestock) {
+            restockOrderItems($pdo, $schema, $id);
+        }
+
+        $pdo->commit();
+    } catch (Throwable $e) {
+        $pdo->rollBack();
+        throw $e;
+    }
+
+    $updated = fetchOrderRow($pdo, $schema, $id);
+    if (!$updated) {
+        throw new RuntimeException('No se pudo recuperar la orden actualizada.');
+    }
+    return $updated;
+}
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+if ($method === 'OPTIONS') {
+    respondJson(204);
+}
+
+try {
+    $schema = detectOrdersSchema($pdo);
+    ensureDeliveryTable($pdo, $schema['order_table'], $schema['order_id']);
+} catch (Throwable $e) {
+    respondError(500, 'No se pudo preparar el servicio de órdenes.', ['detail' => $e->getMessage()]);
+}
+
+$id = isset($_GET['id']) ? (int) $_GET['id'] : null;
+
+try {
+    switch ($method) {
+        case 'GET':
+            if ($id) {
+                $order = fetchOrderRow($pdo, $schema, $id);
+                if (!$order) {
+                    respondError(404, 'Orden no encontrada.');
+                }
+                $with = strtolower(trim((string) ($_GET['with'] ?? '')));
+                $includeItems = false;
+                if ($with !== '') {
+                    $includeItems = in_array('items', array_map('trim', explode(',', $with)), true);
+                }
+                if (!$includeItems && isset($_GET['with_items'])) {
+                    $includeItems = filter_var($_GET['with_items'], FILTER_VALIDATE_BOOLEAN);
+                }
+                if ($includeItems) {
+                    $order['items'] = fetchOrderItems($pdo, $schema, $id);
+                }
+                respondJson(200, ['ok' => true, 'order' => $order]);
+            }
+
+            $statuses = extractStatusesFromQuery($_GET['status'] ?? []);
+            $search = isset($_GET['q']) ? trim((string) $_GET['q']) : '';
+            $limit = isset($_GET['limit']) ? (int) $_GET['limit'] : 200;
+            $orders = fetchOrdersList($pdo, $schema, [
+                'statuses' => $statuses,
+                'search' => $search,
+                'limit' => $limit,
+            ]);
+            respondJson(200, [
+                'ok' => true,
+                'count' => count($orders),
+                'orders' => $orders,
+            ]);
+
+        case 'PATCH':
+        case 'PUT':
+            if (!$id) {
+                respondError(400, 'Falta el identificador de la orden.');
+            }
+            $payload = readJsonInput();
+            $order = updateOrder($pdo, $schema, $id, $payload);
+            if (isset($_GET['with']) && strpos((string) $_GET['with'], 'items') !== false) {
+                $order['items'] = fetchOrderItems($pdo, $schema, $id);
+            }
+            respondJson(200, ['ok' => true, 'order' => $order]);
+
+        default:
+            respondError(405, 'Método no permitido.');
+    }
+} catch (InvalidArgumentException $e) {
+    respondError(422, $e->getMessage());
+} catch (RuntimeException $e) {
+    respondError(404, $e->getMessage());
+} catch (Throwable $e) {
+    respondError(500, 'Ocurrió un error al procesar la solicitud.', ['detail' => $e->getMessage()]);
+}

--- a/ventas.html
+++ b/ventas.html
@@ -1,0 +1,437 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Gestión de Ventas - Joyería Mares</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="css/style.css" rel="stylesheet" />
+  <style>
+    body {
+      font-family: 'Poppins', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      background: linear-gradient(135deg, #e0f7fa, #f3e5f5);
+      min-height: 100vh;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .sales-header {
+      background: linear-gradient(180deg, #1e3c72, #2a5298);
+      color: #fff;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 12px 32px rgba(30, 60, 114, 0.35);
+    }
+
+    .sales-header h1 {
+      font-size: 1.8rem;
+      margin: 0;
+      font-weight: 700;
+    }
+
+    .sales-header .lead {
+      margin-bottom: 0;
+      opacity: 0.85;
+    }
+
+    .sales-header .sales-user {
+      font-size: 0.95rem;
+      opacity: 0.9;
+    }
+
+    .sales-header .btn {
+      box-shadow: none;
+    }
+
+    main {
+      flex: 1;
+      width: 100%;
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 3rem;
+    }
+
+    .section-card {
+      background: #fff;
+      border-radius: 20px;
+      padding: 1.75rem;
+      box-shadow: 0 15px 35px rgba(30, 60, 114, 0.15);
+      margin-bottom: 2rem;
+    }
+
+    .orders-toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .orders-status-filter {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .orders-filter-label {
+      font-weight: 600;
+      color: #1f2a40;
+    }
+
+    .orders-status-option input {
+      margin-right: 0.3rem;
+    }
+
+    .orders-toolbar-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    #tblPedidos thead th {
+      text-transform: uppercase;
+      font-size: 0.75rem;
+      letter-spacing: 0.05em;
+    }
+
+    .orders-table tbody tr {
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .orders-table tbody tr:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 10px 28px rgba(31, 42, 64, 0.12);
+    }
+
+    .order-mini-meta {
+      font-size: 0.8rem;
+      color: #6c757d;
+      display: block;
+    }
+
+    .order-meta-muted {
+      display: block;
+      font-size: 0.75rem;
+      color: #a0a8b5;
+    }
+
+    .orders-table .actions-column > .btn {
+      margin-left: 0.25rem;
+      margin-bottom: 0.35rem;
+    }
+
+    .orders-table .actions-column > .btn:first-child {
+      margin-left: 0;
+    }
+
+    .orders-table .actions-column {
+      white-space: nowrap;
+    }
+
+    .status-badge {
+      display: inline-block;
+      padding: 0.2rem 0.6rem;
+      border-radius: 999px;
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .badge-soft-warning { background: rgba(255, 193, 7, 0.15); color: #856404; }
+    .badge-soft-info { background: rgba(23, 162, 184, 0.18); color: #0f6674; }
+    .badge-soft-success { background: rgba(40, 167, 69, 0.18); color: #155724; }
+    .badge-soft-danger { background: rgba(220, 53, 69, 0.18); color: #7b131f; }
+    .badge-soft-secondary { background: rgba(108, 117, 125, 0.18); color: #343a40; }
+
+    .order-delivery-chip {
+      display: inline-block;
+      padding: 0.2rem 0.65rem;
+      border-radius: 12px;
+      background: rgba(42, 82, 152, 0.1);
+      color: #2a5298;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+
+    .order-delivery-chip.unassigned {
+      background: rgba(220, 53, 69, 0.12);
+      color: #c82333;
+    }
+
+    .order-payment-chip {
+      display: inline-block;
+      padding: 0.2rem 0.6rem;
+      border-radius: 8px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+
+    .order-payment-chip.confirmed {
+      background: rgba(40, 167, 69, 0.12);
+      color: #155724;
+    }
+
+    .order-payment-chip.pending {
+      background: rgba(255, 193, 7, 0.12);
+      color: #856404;
+    }
+
+    .order-modal-box {
+      border: 1px solid rgba(30, 60, 114, 0.12);
+      border-radius: 12px;
+      padding: 1rem;
+      background: rgba(248, 249, 252, 0.65);
+      height: 100%;
+    }
+
+    .order-modal-timeline {
+      list-style: none;
+      padding-left: 0;
+      margin-bottom: 0;
+    }
+
+    .order-modal-timeline li {
+      position: relative;
+      padding-left: 1.25rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .order-modal-timeline li::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0.3rem;
+      width: 0.5rem;
+      height: 0.5rem;
+      border-radius: 999px;
+      background: #1e3c72;
+    }
+
+    .order-modal-timeline li.text-muted::before {
+      background: #ced4da;
+    }
+
+    .modal .custom-control {
+      padding-left: 1.75rem;
+    }
+
+    .modal .custom-control-label::before,
+    .modal .custom-control-label::after {
+      left: -1.75rem;
+    }
+
+    @media (max-width: 768px) {
+      .orders-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .orders-toolbar-actions {
+        width: 100%;
+      }
+
+      .orders-toolbar-actions .input-group {
+        width: 100%;
+      }
+
+      main {
+        padding: 1.5rem 1rem 2rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header class="sales-header">
+    <div class="d-flex flex-wrap align-items-center">
+      <div>
+        <h1>Gestión de Ventas</h1>
+        <p class="lead mb-1">Actualiza estados de pedidos contra entrega y coordina tus repartos.</p>
+        <p class="sales-user mb-0">Sesión iniciada como <strong id="vendorName">—</strong> (<span id="vendorEmail">—</span>)</p>
+      </div>
+      <button id="logoutVendor" class="btn btn-outline-light btn-sm ml-auto">Cerrar sesión</button>
+    </div>
+  </header>
+
+  <main>
+    <section class="section-card">
+      <div class="d-flex flex-wrap align-items-center mb-3">
+        <div>
+          <h2 class="h4 mb-1">Pedidos contra entrega</h2>
+          <p class="text-muted mb-0">Filtra los pedidos pendientes y enviados, asigna repartidores y registra los cobros.</p>
+        </div>
+        <button id="btnPedidosReload" class="btn btn-outline-primary btn-sm ml-auto">Actualizar</button>
+      </div>
+
+      <div class="orders-toolbar">
+        <div class="orders-status-filter">
+          <span class="orders-filter-label">Mostrar:</span>
+          <label class="orders-status-option mb-0">
+            <input type="checkbox" value="pendiente" data-order-status-filter checked /> Pendientes
+          </label>
+          <label class="orders-status-option mb-0">
+            <input type="checkbox" value="enviado" data-order-status-filter checked /> Enviadas
+          </label>
+          <label class="orders-status-option mb-0">
+            <input type="checkbox" value="pagado" data-order-status-filter /> Pagadas
+          </label>
+          <label class="orders-status-option mb-0">
+            <input type="checkbox" value="cancelado" data-order-status-filter /> Canceladas
+          </label>
+        </div>
+        <div class="orders-toolbar-actions">
+          <div class="input-group input-group-sm">
+            <div class="input-group-prepend">
+              <span class="input-group-text"><i class="fas fa-search"></i></span>
+            </div>
+            <input id="ordersSearch" type="search" class="form-control" placeholder="Buscar cliente, orden o repartidor" />
+          </div>
+          <button id="ordersClearFilters" type="button" class="btn btn-link btn-sm text-muted">Limpiar</button>
+        </div>
+      </div>
+
+      <div id="ordersAlert" class="alert alert-danger d-none" role="alert"></div>
+
+      <div class="table-responsive shadow-sm rounded-lg">
+        <table id="tblPedidos" class="table table-hover orders-table mb-0">
+          <thead class="thead-light">
+            <tr>
+              <th>Orden</th>
+              <th>Cliente</th>
+              <th>Contacto</th>
+              <th>Entrega</th>
+              <th>Pago</th>
+              <th>Total</th>
+              <th>Actualización</th>
+              <th class="text-right">Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td colspan="8" class="text-center text-muted py-4">Cargando pedidos...</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+
+  <div class="modal fade" id="modalPedidoEstado" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+      <div class="modal-content">
+        <form id="frmPedidoEstado">
+          <div class="modal-header">
+            <h5 id="orderModalTitle" class="modal-title">Actualizar pedido</h5>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Cerrar">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <input type="hidden" id="orderModalId" />
+            <div id="orderModalAlert" class="alert alert-danger d-none" role="alert"></div>
+
+            <div class="row">
+              <div class="col-md-6 mb-3">
+                <div class="order-modal-box">
+                  <h6 class="text-uppercase text-muted small mb-2">Cliente</h6>
+                  <p id="orderModalCustomer" class="mb-1 font-weight-semibold">—</p>
+                  <p id="orderModalContact" class="mb-1 text-muted">—</p>
+                  <p id="orderModalAddress" class="mb-0 text-muted">—</p>
+                </div>
+              </div>
+              <div class="col-md-6 mb-3">
+                <div class="order-modal-box">
+                  <h6 class="text-uppercase text-muted small mb-2">Pedido</h6>
+                  <p class="mb-1"><strong>Orden:</strong> <span id="orderModalCode">—</span></p>
+                  <p class="mb-1"><strong>Fecha:</strong> <span id="orderModalDate">—</span></p>
+                  <p class="mb-1"><strong>Método:</strong> <span id="orderModalPayment">—</span></p>
+                  <p class="mb-0"><strong>Total:</strong> <span id="orderModalTotal">—</span></p>
+                </div>
+              </div>
+            </div>
+
+            <div class="order-modal-box mb-3">
+              <h6 class="text-uppercase text-muted small mb-2">Seguimiento</h6>
+              <ul class="order-modal-timeline mb-0" id="orderModalTimeline">
+                <li class="text-muted">Cargando...</li>
+              </ul>
+            </div>
+
+            <div class="order-modal-box mb-3">
+              <h6 class="text-uppercase text-muted small mb-2">Productos</h6>
+              <div class="table-responsive">
+                <table class="table table-sm table-striped mb-0">
+                  <thead>
+                    <tr>
+                      <th>Producto</th>
+                      <th class="text-right">Cantidad</th>
+                      <th class="text-right">Precio</th>
+                      <th class="text-right">Subtotal</th>
+                    </tr>
+                  </thead>
+                  <tbody id="orderModalItemsBody">
+                    <tr>
+                      <td colspan="4" class="text-center text-muted py-3">Cargando productos...</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <div class="form-row">
+              <div class="form-group col-md-6">
+                <label for="orderStatusSelect">Cambiar estado</label>
+                <select id="orderStatusSelect" class="form-control" required>
+                  <option value="pendiente">Pendiente</option>
+                  <option value="enviado">Enviado</option>
+                  <option value="pagado">Pagado</option>
+                  <option value="cancelado">Cancelado</option>
+                </select>
+              </div>
+              <div class="form-group col-md-6">
+                <label for="orderDeliveryName" class="d-flex justify-content-between">
+                  <span>Repartidor asignado</span>
+                  <small class="text-muted">Obligatorio para enviar</small>
+                </label>
+                <input id="orderDeliveryName" type="text" class="form-control" placeholder="Nombre del repartidor" />
+              </div>
+            </div>
+
+            <div class="form-row">
+              <div class="form-group col-md-6">
+                <label for="orderDeliveryContact">Contacto del repartidor</label>
+                <input id="orderDeliveryContact" type="text" class="form-control" placeholder="Teléfono o identificación" />
+              </div>
+              <div class="form-group col-md-6 d-flex align-items-center">
+                <div class="custom-control custom-checkbox">
+                  <input type="checkbox" class="custom-control-input" id="orderPaymentConfirmed" />
+                  <label class="custom-control-label" for="orderPaymentConfirmed">Pago contra entrega confirmado</label>
+                </div>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label for="orderNotes">Notas internas</label>
+              <textarea id="orderNotes" class="form-control" rows="2" placeholder="Comentarios o instrucciones adicionales"></textarea>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-danger mr-auto" id="orderModalCancelBtn">Cancelar pedido</button>
+            <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">Cerrar</button>
+            <button type="submit" class="btn btn-primary" id="orderModalSubmitBtn">Guardar cambios</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+  <script src="https://kit.fontawesome.com/aa5f332820.js" crossorigin="anonymous"></script>
+  <script src="Js/vendor-sales.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated `ventas.html` page so vendedores can filtrar, buscar y actualizar pedidos contra entrega
- implement `Js/vendor-sales.js` to cargar pedidos, gestionar estados y controlar asignaciones de repartidor y confirmaciones de pago
- actualizar `Js/auth.js` para redirigir a la vista de gestión de ventas cuando el rol autenticado es vendedor

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ec1c8ec6088325803862f3ed6d2ba7