### PR TITLE
Normalize role handling for admin and vendor pages

### DIFF
--- a/Js/admin.js
+++ b/Js/admin.js
@@ -1,12 +1,35 @@
 const API_BASE = 'https://joyeria-full-stack-production.up.railway.app'; // ✅
 
 /* ====== Guardas de sesión ====== */
+function normalizeRoleValue(rawRole) {
+  if (rawRole === null || rawRole === undefined) return '';
+
+  const numericRole = Number(rawRole);
+  if (!Number.isNaN(numericRole) && Number.isFinite(numericRole)) {
+    if (numericRole === 1) return 'admin';
+    if (numericRole === 2) return 'vendedor';
+  }
+
+  const text = rawRole.toString().trim().toLowerCase();
+  if (!text) return '';
+
+  if (['1', 'admin', 'administrator', 'administrador'].includes(text)) {
+    return 'admin';
+  }
+  if (['2', 'vendedor', 'seller', 'ventas', 'salesperson', 'sales'].includes(text)) {
+    return 'vendedor';
+  }
+  return text;
+}
+
 const token = localStorage.getItem('token');
 const role  = localStorage.getItem('role');
+const rawRole = localStorage.getItem('role_raw');
+const normalizedRole = normalizeRoleValue(role ?? rawRole);
 // En auth.js guardas con la clave 'email', no 'userEmail'
 const email = localStorage.getItem('email'); // ✅
 
-if (!token || role !== 'admin') {
+if (!token || normalizedRole !== 'admin') {
   const next = encodeURIComponent('admin.html');
   window.location.href = `login.html?next=${next}`;
 }

--- a/Js/auth.js
+++ b/Js/auth.js
@@ -2,17 +2,42 @@
 const API_BASE = 'https://joyeria-full-stack-production.up.railway.app';
 const $ = (s, ctx=document) => ctx.querySelector(s);
 
+function normalizeRoleValue(rawRole) {
+  if (rawRole === null || rawRole === undefined) return '';
+
+  const numericRole = Number(rawRole);
+  if (!Number.isNaN(numericRole) && Number.isFinite(numericRole)) {
+    if (numericRole === 1) return 'admin';
+    if (numericRole === 2) return 'vendedor';
+  }
+
+  const text = rawRole.toString().trim().toLowerCase();
+  if (!text) return '';
+
+  if (['1', 'admin', 'administrator', 'administrador'].includes(text)) {
+    return 'admin';
+  }
+  if (['2', 'vendedor', 'seller', 'ventas', 'salesperson', 'sales'].includes(text)) {
+    return 'vendedor';
+  }
+  return text;
+}
+
 function saveSession({ token, user }) {
   // ajústalo si tu backend usa mayúsculas distintas
-  const role = user.role ?? user.Role ?? user.rol ?? user.Rol ?? user.perfil;
+  const rawRole = user.role ?? user.Role ?? user.rol ?? user.Rol ?? user.perfil ?? user.role_id ?? user.RoleId;
+  const normalizedRole = normalizeRoleValue(rawRole);
   localStorage.setItem('token', token);
-  localStorage.setItem('role',  role);
+  localStorage.setItem('role',  normalizedRole);
+  if (rawRole !== null && rawRole !== undefined) {
+    localStorage.setItem('role_raw', rawRole);
+  }
   localStorage.setItem('name',  user.nombre || user.name || '');
   localStorage.setItem('email', user.email  || '');
 }
 
 function redirectByRole(role) {
-  const normalized = (role || '').toString().trim().toLowerCase();
+  const normalized = normalizeRoleValue(role);
   if (normalized === 'admin') {
     window.location.href = 'admin.html';
   } else if (normalized === 'vendedor' || normalized === 'seller') {

--- a/Js/vendor-sales.js
+++ b/Js/vendor-sales.js
@@ -1,7 +1,29 @@
+function normalizeRoleValue(rawRole) {
+  if (rawRole === null || rawRole === undefined) return '';
+
+  const numericRole = Number(rawRole);
+  if (!Number.isNaN(numericRole) && Number.isFinite(numericRole)) {
+    if (numericRole === 1) return 'admin';
+    if (numericRole === 2) return 'vendedor';
+  }
+
+  const text = rawRole.toString().trim().toLowerCase();
+  if (!text) return '';
+
+  if (['1', 'admin', 'administrator', 'administrador'].includes(text)) {
+    return 'admin';
+  }
+  if (['2', 'vendedor', 'seller', 'ventas', 'salesperson', 'sales'].includes(text)) {
+    return 'vendedor';
+  }
+  return text;
+}
+
 const allowedVendorRoles = new Set(['vendedor', 'seller']);
 const token = localStorage.getItem('token');
 const storedRole = localStorage.getItem('role');
-const normalizedRole = (storedRole || '').trim().toLowerCase();
+const storedRawRole = localStorage.getItem('role_raw');
+const normalizedRole = normalizeRoleValue(storedRole ?? storedRawRole);
 
 if (!token || !allowedVendorRoles.has(normalizedRole)) {
   const next = encodeURIComponent('ventas.html');


### PR DESCRIPTION
## Summary
- normalize role values when saving the session so numeric role ids map to the expected strings
- reuse the normalized role in the admin and vendor dashboards to keep access guards consistent

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ec2d1f0fb88325aabf03b926fddd98