### PR TITLE
Switch to local APIs and support product image storage

### DIFF
--- a/Js/admin.js
+++ b/Js/admin.js
@@ -1,12 +1,39 @@
-const API_BASE = 'https://joyeria-full-stack-production.up.railway.app'; // ✅
+const API_BASE = '';
+const REMOTE_BASE = 'https://joyeria-full-stack-production.up.railway.app';
+const PRODUCTS_ENDPOINT = '/api/products.php';
+const PRODUCT_IMAGE_ENDPOINT = '/api/product-image.php';
+const ORDERS_ENDPOINT = '/api/orders.php';
 
 /* ====== Guardas de sesión ====== */
+function normalizeRoleValue(rawRole) {
+  if (rawRole === null || rawRole === undefined) return '';
+
+  const numericRole = Number(rawRole);
+  if (!Number.isNaN(numericRole) && Number.isFinite(numericRole)) {
+    if (numericRole === 1) return 'admin';
+    if (numericRole === 2) return 'vendedor';
+  }
+
+  const text = rawRole.toString().trim().toLowerCase();
+  if (!text) return '';
+
+  if (['1', 'admin', 'administrator', 'administrador'].includes(text)) {
+    return 'admin';
+  }
+  if (['2', 'vendedor', 'seller', 'ventas', 'salesperson', 'sales'].includes(text)) {
+    return 'vendedor';
+  }
+  return text;
+}
+
 const token = localStorage.getItem('token');
 const role  = localStorage.getItem('role');
+const rawRole = localStorage.getItem('role_raw');
+const normalizedRole = normalizeRoleValue(role ?? rawRole);
 // En auth.js guardas con la clave 'email', no 'userEmail'
 const email = localStorage.getItem('email'); // ✅
 
-if (!token || role !== 'admin') {
+if (!token || normalizedRole !== 'admin') {
   const next = encodeURIComponent('admin.html');
   window.location.href = `login.html?next=${next}`;
 }
@@ -34,10 +61,32 @@ const fileInput  = document.getElementById('fileInput');
 const imgPreview = document.getElementById('imgPreview');
 
 /* ====== Helpers HTTP ====== */
+function resolveApiPath(path) {
+  if (!path) return path;
+  if (path.startsWith('http')) return path;
+  if (path.startsWith('/api/products/')) {
+    const id = path.slice('/api/products/'.length).replace(/\/?$/, '');
+    if (id) {
+      return `${PRODUCTS_ENDPOINT}?id=${encodeURIComponent(id)}`;
+    }
+    return PRODUCTS_ENDPOINT;
+  }
+  if (path === '/api/products') {
+    return PRODUCTS_ENDPOINT;
+  }
+  if (path.startsWith('/api/orders')) {
+    return ORDERS_ENDPOINT + path.slice('/api/orders'.length);
+  }
+  return path;
+}
+
 async function apiFetch(path, options = {}) {
-  const res = await fetch(`${API_BASE}${path}`, options);
+  const url = resolveApiPath(path);
+  const res = await fetch(url, options);
   const data = await res.json().catch(() => ({}));
-  if (!res.ok) throw new Error(data.error || data.message || `HTTP ${res.status}`);
+  if (!res.ok || data.ok === false) {
+    throw new Error(data.error || data.message || `HTTP ${res.status}`);
+  }
   return data;
 }
 
@@ -808,8 +857,24 @@ if (ordersReloadBtn) {
 }
 
 async function loadProductos() {
-  const list = await apiFetch('/api/products'); // ✅ absoluto
-  $tbody.innerHTML = list.map(rowHTML).join('');
+  try {
+    const data = await apiFetch('/api/products');
+    const list = Array.isArray(data)
+      ? data
+      : Array.isArray(data.products)
+        ? data.products
+        : [];
+    if (!$tbody) return;
+    if (!list.length) {
+      $tbody.innerHTML = '<tr><td colspan="7" class="text-center text-muted py-3">Sin productos registrados.</td></tr>';
+      return;
+    }
+    $tbody.innerHTML = list.map(rowHTML).join('');
+  } catch (err) {
+    if ($tbody) {
+      $tbody.innerHTML = `<tr><td colspan="7" class="text-center text-danger py-3">${err.message}</td></tr>`;
+    }
+  }
 }
 loadProductos();
 
@@ -855,8 +920,11 @@ $frm.addEventListener('submit', async (e) => {
     body: JSON.stringify(payload)
   };
 
-  const path = id ? `/api/products/${id}` : '/api/products';
-  await apiFetch(path, opts); // ✅ absoluto + manejo de error
+  const path = id
+    ? `${PRODUCTS_ENDPOINT}?id=${encodeURIComponent(id)}`
+    : PRODUCTS_ENDPOINT;
+
+  await apiFetch(path, opts);
   $modal.modal('hide');
   await loadProductos();
 });
@@ -869,7 +937,8 @@ $tbody.addEventListener('click', async (e) => {
 
   if (e.target.classList.contains('btn-edit')) {
     document.getElementById('modalTitle').textContent = 'Editar producto';
-    const p = await apiFetch(`/api/products/${id}`); // ✅
+    const data = await apiFetch(`${PRODUCTS_ENDPOINT}?id=${encodeURIComponent(id)}`);
+    const p = data.product ?? data;
 
     document.getElementById('p_id').value        = p.Id;
     document.getElementById('p_codigo').value    = p.Codigo || '';
@@ -894,7 +963,7 @@ $tbody.addEventListener('click', async (e) => {
 
   if (e.target.classList.contains('btn-del')) {
     if (!confirm('¿Borrar este producto?')) return;
-    await apiFetch(`/api/products/${id}`, {
+    await apiFetch(`${PRODUCTS_ENDPOINT}?id=${encodeURIComponent(id)}`, {
       method: 'DELETE',
       headers: { 'Authorization': `Bearer ${token}` }
     }); // ✅
@@ -954,9 +1023,10 @@ async function handleFile(file) {
 
   try {
     const formData = new FormData();
+    formData.append('product_id', productId);
     formData.append('file', file);
 
-    const res = await fetch(`${API_BASE}/api/products/${productId}/image`, { // ✅
+    const res = await fetch(PRODUCT_IMAGE_ENDPOINT, {
       method: 'POST',
       headers: { 'Authorization': `Bearer ${token}` },
       body: formData

--- a/Js/api.js
+++ b/Js/api.js
@@ -1,18 +1,53 @@
 // /public/js/api.js
-export const API_BASE = 'https://joyeria-full-stack-production.up.railway.app';
+export const API_BASE = '';
+
+const REMOTE_BASE = 'https://joyeria-full-stack-production.up.railway.app';
+const LOCAL_PRODUCTS_ENDPOINT = '/api/products.php';
+const LOCAL_CATEGORIES_ENDPOINT = '/api/categories.php';
+
+async function fetchJson(url, options) {
+  const res = await fetch(url, options);
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || data.ok === false) {
+    throw new Error(data.error || data.message || `Error de solicitud (${res.status})`);
+  }
+  return data;
+}
 
 // Productos
 export async function getProducts() {
-  const res = await fetch(`${API_BASE}/api/products`);
-  if (!res.ok) throw new Error('No se pudieron cargar productos');
-  return res.json();
+  try {
+    const data = await fetchJson(LOCAL_PRODUCTS_ENDPOINT);
+    if (Array.isArray(data)) return data;
+    if (Array.isArray(data.products)) return data.products;
+    if (Array.isArray(data.data)) return data.data;
+    return [];
+  } catch (err) {
+    console.warn('Fallo la carga local de productos, intentando con la API remota.', err);
+    const data = await fetchJson(`${REMOTE_BASE}/api/products`);
+    if (Array.isArray(data)) return data;
+    if (Array.isArray(data.products)) return data.products;
+    if (Array.isArray(data.data)) return data.data;
+    return [];
+  }
 }
 
 // Categorías
 export async function getCategories() {
-  const res = await fetch(`${API_BASE}/api/categories`);
-  if (!res.ok) throw new Error('No se pudieron cargar las categorías');
-  return res.json();
+  try {
+    const data = await fetchJson(LOCAL_CATEGORIES_ENDPOINT);
+    if (Array.isArray(data)) return data;
+    if (Array.isArray(data.categories)) return data.categories;
+    if (Array.isArray(data.data)) return data.data;
+    return [];
+  } catch (err) {
+    console.warn('Fallo la carga local de categorías, intentando con la API remota.', err);
+    const data = await fetchJson(`${REMOTE_BASE}/api/categories`);
+    if (Array.isArray(data)) return data;
+    if (Array.isArray(data.categories)) return data.categories;
+    if (Array.isArray(data.data)) return data.data;
+    return [];
+  }
 }
 
 // Alias comunes
@@ -25,7 +60,7 @@ export async function validateCoupon(code, subtotal) {
     return { valid: false, ok: false, message: 'Ingresa un cupón', tipo: null, valor: 0, descuento: 0 };
   }
 
-  const url = new URL(`${API_BASE}/api/coupons/validate`);
+  const url = new URL(`${REMOTE_BASE}/api/coupons/validate`);
   url.searchParams.set('codigo', code);
   url.searchParams.set('subtotal', String(subtotal));
 
@@ -45,7 +80,7 @@ export async function validateCoupon(code, subtotal) {
 
 // Ordenes
 export async function createOrder(payload) {
-  const res = await fetch(`${API_BASE}/api/orders`, {
+  const res = await fetch(`${REMOTE_BASE}/api/orders`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)

--- a/Js/auth.js
+++ b/Js/auth.js
@@ -1,21 +1,45 @@
 // Js/auth.js
-const API_BASE = 'https://joyeria-full-stack-production.up.railway.app';
+const LOGIN_ENDPOINT = '/api/login.php';
 const $ = (s, ctx=document) => ctx.querySelector(s);
 
+function normalizeRoleValue(rawRole) {
+  if (rawRole === null || rawRole === undefined) return '';
+
+  const numericRole = Number(rawRole);
+  if (!Number.isNaN(numericRole) && Number.isFinite(numericRole)) {
+    if (numericRole === 1 || numericRole === 4) return 'admin';
+    if (numericRole === 2) return 'ventas';
+  }
+
+  const text = rawRole.toString().trim().toLowerCase();
+  if (!text) return '';
+
+  if (['1', '4', 'admin', 'administrator', 'administrador'].includes(text)) {
+    return 'admin';
+  }
+  if (['2', 'ventas', 'vendedor', 'seller', 'sales', 'salesperson'].includes(text)) {
+    return 'ventas';
+  }
+  return text;
+}
+
 function saveSession({ token, user }) {
-  // ajústalo si tu backend usa mayúsculas distintas
-  const role = user.role ?? user.Role ?? user.rol ?? user.Rol ?? user.perfil;
-  localStorage.setItem('token', token);
-  localStorage.setItem('role',  role);
+  const rawRole = user.role ?? user.Role ?? user.rol ?? user.Rol ?? user.perfil ?? user.role_id ?? user.RoleId ?? user.roleId;
+  const normalizedRole = normalizeRoleValue(rawRole);
+  localStorage.setItem('token', token || '');
+  localStorage.setItem('role', normalizedRole);
+  if (rawRole !== null && rawRole !== undefined) {
+    localStorage.setItem('role_raw', rawRole);
+  }
   localStorage.setItem('name',  user.nombre || user.name || '');
   localStorage.setItem('email', user.email  || '');
 }
 
 function redirectByRole(role) {
-  const normalized = (role || '').toString().trim().toLowerCase();
+  const normalized = normalizeRoleValue(role);
   if (normalized === 'admin') {
     window.location.href = 'admin.html';
-  } else if (normalized === 'vendedor' || normalized === 'seller') {
+  } else if (normalized === 'ventas' || normalized === 'vendedor' || normalized === 'seller') {
     window.location.href = 'ventas.html';
   } else {
     window.location.href = 'index.html';
@@ -24,17 +48,17 @@ function redirectByRole(role) {
 
 function showError(msg){ alert(msg || 'Error inesperado'); }
 
-async function loginRailway(email, password){
-  const res = await fetch(`${API_BASE}/api/auth/login`, {
+async function loginLocal(email, password){
+  const res = await fetch(LOGIN_ENDPOINT, {
     method: 'POST',
     headers: {'Content-Type':'application/json'},
-    body: JSON.stringify({ Email: email, Password: password })
+    body: JSON.stringify({ email, password })
   });
   const data = await res.json().catch(()=> ({}));
   if (!res.ok || data.ok === false) {
     throw new Error(data.error || (data.errors && data.errors[0]?.msg) || 'Credenciales inválidas');
   }
-  return data; // { ok:true, token, user:{ role:'admin', ... } }
+  return data;
 }
 
 document.getElementById('loginForm')?.addEventListener('submit', async (e)=>{
@@ -43,7 +67,7 @@ document.getElementById('loginForm')?.addEventListener('submit', async (e)=>{
   const password = $('#password').value;
 
   try {
-    const data = await loginRailway(email, password);
+    const data = await loginLocal(email, password);
     saveSession({ token: data.token, user: data.user });
     redirectByRole(localStorage.getItem('role'));
   } catch (err) {

--- a/Js/main.js
+++ b/Js/main.js
@@ -98,9 +98,16 @@ function renderProducts(list) {
 
     // Prefija imagen si viene relativa ("/uploads/...") o "img/..."
     const raw = p.ImagenUrl || '';
-    const imgSrc = raw.startsWith('http')
-      ? raw
-      : `${API_BASE}${raw.startsWith('/') ? '' : '/'}${raw}`;
+    let imgSrc = '';
+    if (raw.startsWith('data:')) {
+      imgSrc = raw;
+    } else if (raw.startsWith('http')) {
+      imgSrc = raw;
+    } else if (raw) {
+      imgSrc = `${API_BASE}${raw.startsWith('/') ? '' : '/'}${raw}`;
+    } else {
+      imgSrc = 'https://via.placeholder.com/320x320?text=Producto';
+    }
 
     const stockBadge = agotado
       ? `<span class="badge badge-danger">Agotado</span>`

--- a/Js/vendor-sales.js
+++ b/Js/vendor-sales.js
@@ -1,9 +1,21 @@
-const allowedVendorRoles = new Set(['vendedor', 'seller']);
-const token = localStorage.getItem('token');
-const storedRole = localStorage.getItem('role');
-const normalizedRole = (storedRole || '').trim().toLowerCase();
+const ORDERS_ENDPOINT = '/api/orders.php';
 
-if (!token || !allowedVendorRoles.has(normalizedRole)) {
+function normalizeRole(rawRole) {
+  if (rawRole === null || rawRole === undefined) return '';
+  const numeric = Number(rawRole);
+  if (!Number.isNaN(numeric)) {
+    if (numeric === 1 || numeric === 4) return 'admin';
+    if (numeric === 2) return 'ventas';
+  }
+  const text = rawRole.toString().trim().toLowerCase();
+  if (['1', '4', 'admin', 'administrator', 'administrador'].includes(text)) return 'admin';
+  if (['2', 'ventas', 'vendedor', 'seller', 'sales', 'salesperson'].includes(text)) return 'ventas';
+  return text;
+}
+
+const token = localStorage.getItem('token');
+const storedRole = normalizeRole(localStorage.getItem('role') ?? localStorage.getItem('role_raw'));
+if (!token || !['ventas', 'vendedor', 'seller'].includes(storedRole)) {
   const next = encodeURIComponent('ventas.html');
   window.location.href = `login.html?next=${next}`;
 }
@@ -13,17 +25,21 @@ const vendorEmail = localStorage.getItem('email') || '—';
 
 const vendorNameLabel = document.getElementById('vendorName');
 const vendorEmailLabel = document.getElementById('vendorEmail');
-
 if (vendorNameLabel) vendorNameLabel.textContent = vendorName;
 if (vendorEmailLabel) vendorEmailLabel.textContent = vendorEmail;
 
-document.getElementById('logoutVendor')?.addEventListener('click', () => {
+const logoutBtn = document.getElementById('logoutVendor');
+logoutBtn?.addEventListener('click', () => {
   localStorage.removeItem('token');
   localStorage.removeItem('role');
+  localStorage.removeItem('role_raw');
   localStorage.removeItem('name');
   localStorage.removeItem('email');
   window.location.href = 'index.html';
 });
+
+const money = new Intl.NumberFormat('es-GT', { style: 'currency', currency: 'GTQ' });
+const dateTime = new Intl.DateTimeFormat('es-GT', { dateStyle: 'medium', timeStyle: 'short' });
 
 const $ordersTbody = document.querySelector('#tblPedidos tbody');
 const ordersAlert = document.getElementById('ordersAlert');
@@ -33,7 +49,7 @@ const ordersClearBtn = document.getElementById('ordersClearFilters');
 const ordersStatusCheckboxes = document.querySelectorAll('[data-order-status-filter]');
 
 const orderModalElement = document.getElementById('modalPedidoEstado');
-const orderModal = $('#modalPedidoEstado');
+const orderModal = window.jQuery ? window.jQuery('#modalPedidoEstado') : null;
 const orderModalForm = document.getElementById('frmPedidoEstado');
 const orderModalTitle = document.getElementById('orderModalTitle');
 const orderModalAlert = document.getElementById('orderModalAlert');
@@ -55,33 +71,27 @@ const orderNotesInput = document.getElementById('orderNotes');
 const orderModalCancelBtn = document.getElementById('orderModalCancelBtn');
 const orderModalSubmitBtn = document.getElementById('orderModalSubmitBtn');
 
-const money = new Intl.NumberFormat('es-GT', { style: 'currency', currency: 'GTQ' });
-const numberFormatter = new Intl.NumberFormat('es-GT', { minimumFractionDigits: 0, maximumFractionDigits: 2 });
-const dateTimeFormatter = new Intl.DateTimeFormat('es-GT', { dateStyle: 'medium', timeStyle: 'short' });
-
-const DEFAULT_ORDER_STATUSES = ['pendiente', 'enviado'];
 const ordersState = {
   list: [],
   loading: false,
-  statusFilters: new Set(DEFAULT_ORDER_STATUSES),
+  statusFilters: new Set(['pendiente', 'enviado']),
   search: '',
 };
 
-let currentOrderDetail = null;
-let ordersAlertTimer = null;
+let currentOrder = null;
+let alertTimer = null;
 
-function escapeHtml(value) {
-  if (value === null || value === undefined) return '';
-  return String(value)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+function buildHeaders(extra = {}) {
+  const headers = { Accept: 'application/json', ...extra };
+  if (token) {
+    headers.Authorization = token.startsWith('Bearer ') ? token : `Bearer ${token}`;
+  }
+  return headers;
 }
 
-function normalizeStatusValue(value) {
-  const key = typeof value === 'string' ? value.trim().toLowerCase() : '';
+function normalizeStatus(value) {
+  const text = (value || '').toString().trim().toLowerCase();
+  if (!text) return 'pendiente';
   const map = {
     pending: 'pendiente',
     procesando: 'pendiente',
@@ -97,23 +107,16 @@ function normalizeStatusValue(value) {
     pagado: 'pagado',
     pagada: 'pagado',
     paid: 'pagado',
-    completado: 'pagado',
-    completada: 'pagado',
     completed: 'pagado',
     cancelado: 'cancelado',
     cancelada: 'cancelado',
     cancelled: 'cancelado',
-    anulado: 'cancelado',
-    anulada: 'cancelado',
     void: 'cancelado',
   };
-  const normalized = map[key] ?? key;
-  const allowed = new Set(['pendiente', 'enviado', 'pagado', 'cancelado']);
-  if (allowed.has(normalized)) return normalized;
-  return 'pendiente';
+  return map[text] || text;
 }
 
-function formatStatusLabel(status) {
+function statusLabel(status) {
   switch (status) {
     case 'pendiente': return 'Pendiente';
     case 'enviado': return 'Enviado';
@@ -123,99 +126,7 @@ function formatStatusLabel(status) {
   }
 }
 
-function parseDateValue(value) {
-  if (!value) return null;
-  const normalized = value.includes('T') ? value : value.replace(' ', 'T');
-  const date = new Date(normalized);
-  if (!Number.isNaN(date.getTime())) return date;
-  const fallback = new Date(value);
-  return Number.isNaN(fallback.getTime()) ? null : fallback;
-}
-
-function formatDateTime(value) {
-  const date = parseDateValue(value);
-  return date ? dateTimeFormatter.format(date) : '—';
-}
-
-function normalizeOrderFromApi(order = {}) {
-  const rawId = order.id ?? order.Id ?? order.orden_id ?? order.order_id ?? order.OrdenId;
-  const status = normalizeStatusValue(order.status ?? order.estado ?? order.Status ?? order.Estado ?? '');
-  const totalValue = order.total ?? order.Total ?? order.monto_total ?? order.TotalPedido ?? null;
-  const numericTotal = Number(totalValue);
-  const numericId = Number(rawId);
-  const hasNumericId = rawId !== null && rawId !== undefined && !Number.isNaN(numericId);
-
-  return {
-    id: rawId === null || rawId === undefined ? null : (hasNumericId ? numericId : rawId),
-    code: order.code ?? order.codigo ?? order.numero ?? order.numero_orden ?? null,
-    status,
-    status_label: formatStatusLabel(status),
-    total: Number.isFinite(numericTotal) ? numericTotal : (typeof totalValue === 'number' ? totalValue : null),
-    payment_method: order.payment_method ?? order.metodo_pago ?? order.MetodoPago ?? null,
-    payment_reference: order.payment_reference ?? order.referencia_pago ?? order.Referencia ?? null,
-    coupon_code: order.coupon_code ?? order.cupon_codigo ?? order.Cupon ?? null,
-    customer: {
-      name: order.customer?.name ?? order.customer ?? order.cliente ?? order.Nombre ?? null,
-      email: order.customer?.email ?? order.cliente_email ?? order.Email ?? null,
-      phone: order.customer?.phone ?? order.cliente_telefono ?? order.Telefono ?? null,
-      address: order.customer?.address ?? order.customer_address ?? order.cliente_direccion ?? order.Direccion ?? null,
-    },
-    delivery: {
-      person: {
-        id: order.delivery?.person?.id ?? order.repartidor_id ?? null,
-        name: order.delivery?.person?.name ?? order.repartidor_nombre ?? null,
-        contact: order.delivery?.person?.contact ?? order.repartidor_contacto ?? null,
-      },
-      payment_confirmed: Boolean(order.delivery?.payment_confirmed ?? order.pago_confirmado),
-      notes: order.delivery?.notes ?? order.notas ?? null,
-      assigned_at: order.delivery?.assigned_at ?? order.fecha_asignacion ?? null,
-      shipped_at: order.delivery?.shipped_at ?? order.fecha_envio ?? null,
-      paid_at: order.delivery?.paid_at ?? order.fecha_pago ?? null,
-      canceled_at: order.delivery?.canceled_at ?? order.fecha_cancelacion ?? null,
-      updated_at: order.delivery?.updated_at ?? order.gestion_actualizado_en ?? null,
-    },
-    created_at: order.created_at ?? order.creado_en ?? order.Fecha ?? null,
-    updated_at: order.updated_at ?? order.actualizado_en ?? null,
-    items: Array.isArray(order.items) ? order.items : undefined,
-  };
-}
-
-function upsertOrder(order) {
-  const normalized = normalizeOrderFromApi(order);
-  const id = normalized.id;
-  if (id === null || id === undefined) return;
-  const index = ordersState.list.findIndex(item => item.id === id);
-  if (index >= 0) {
-    const current = ordersState.list[index];
-    ordersState.list[index] = {
-      ...current,
-      ...normalized,
-      customer: { ...current.customer, ...normalized.customer },
-      delivery: {
-        ...current.delivery,
-        ...normalized.delivery,
-        person: {
-          ...(current.delivery ? current.delivery.person : {}),
-          ...(normalized.delivery ? normalized.delivery.person : {}),
-        },
-      },
-      items: normalized.items !== undefined ? normalized.items : current.items,
-    };
-  } else {
-    ordersState.list.push(normalized);
-  }
-}
-
-function renderOrdersLoading() {
-  if (!$ordersTbody) return;
-  $ordersTbody.innerHTML = `
-    <tr>
-      <td colspan="8" class="text-center text-muted py-4">Cargando pedidos...</td>
-    </tr>
-  `;
-}
-
-function getStatusBadgeClass(status) {
+function statusBadgeClass(status) {
   switch (status) {
     case 'pendiente': return 'badge-soft-warning';
     case 'enviado': return 'badge-soft-info';
@@ -225,163 +136,313 @@ function getStatusBadgeClass(status) {
   }
 }
 
-function pedidoRowHTML(order) {
-  const idLabel = order.code ? escapeHtml(order.code) : (order.id !== null && order.id !== undefined ? `#${order.id}` : '—');
-  const statusBadge = `<span class="status-badge ${getStatusBadgeClass(order.status)}">${escapeHtml(order.status_label)}</span>`;
-  const customerName = escapeHtml(order.customer?.name || 'Cliente sin nombre');
-  const addressLine = order.customer?.address ? `<div class="order-mini-meta"><i class="fas fa-map-marker-alt mr-1"></i>${escapeHtml(order.customer.address)}</div>` : '';
-  const phoneLine = order.customer?.phone ? `<div class="order-mini-meta"><i class="fas fa-phone mr-1"></i>${escapeHtml(order.customer.phone)}</div>` : '';
-  const emailLine = order.customer?.email ? `<div class="order-mini-meta"><i class="fas fa-envelope mr-1"></i>${escapeHtml(order.customer.email)}</div>` : '';
-  const deliveryName = order.delivery?.person?.name
-    ? `<span class="order-delivery-chip">${escapeHtml(order.delivery.person.name)}</span>`
-    : `<span class="order-delivery-chip unassigned">Sin asignar</span>`;
-  const deliveryContact = order.delivery?.person?.contact ? `<div class="order-mini-meta">${escapeHtml(order.delivery.person.contact)}</div>` : '';
-  const assignedLine = order.delivery?.assigned_at ? `<div class="order-mini-meta">Asignado: ${formatDateTime(order.delivery.assigned_at)}</div>` : '';
-  const shippedLine = order.delivery?.shipped_at ? `<div class="order-mini-meta">Enviado: ${formatDateTime(order.delivery.shipped_at)}</div>` : '';
-  const paymentChipClass = order.delivery?.payment_confirmed ? 'order-payment-chip confirmed' : 'order-payment-chip pending';
-  const paymentChipText = order.delivery?.payment_confirmed ? 'Pago confirmado' : 'Pendiente de cobro';
-  const paymentMethodLine = order.payment_method ? `<div class="order-mini-meta"><i class="fas fa-money-bill-wave mr-1"></i>${escapeHtml(order.payment_method)}</div>` : '';
-  const paymentReferenceLine = order.payment_reference ? `<div class="order-mini-meta">Ref: ${escapeHtml(order.payment_reference)}</div>` : '';
-  const paidLine = order.delivery?.paid_at ? `<div class="order-mini-meta">Pagado: ${formatDateTime(order.delivery.paid_at)}</div>` : '';
-  const updatedRef = order.delivery?.updated_at || order.updated_at || order.delivery?.paid_at || order.delivery?.shipped_at || order.created_at;
-  const updatedLabel = updatedRef ? formatDateTime(updatedRef) : '—';
-  const createdLabel = order.created_at ? formatDateTime(order.created_at) : null;
-  const total = typeof order.total === 'number' && Number.isFinite(order.total) ? money.format(order.total) : '—';
-
-  const actions = [];
-  actions.push(`<button class="btn btn-sm btn-outline-primary" data-order-action="manage" data-order-id="${order.id}">Gestionar</button>`);
-  if (order.status === 'pendiente') {
-    actions.push(`<button class="btn btn-sm btn-outline-info" data-order-action="ship" data-order-id="${order.id}">Marcar enviada</button>`);
-  }
-  if (order.status !== 'pagado' && order.status !== 'cancelado') {
-    actions.push(`<button class="btn btn-sm btn-outline-success" data-order-action="mark-paid" data-order-id="${order.id}">Marcar pagada</button>`);
-  }
-  if (order.status !== 'cancelado') {
-    actions.push(`<button class="btn btn-sm btn-outline-danger" data-order-action="cancel" data-order-id="${order.id}">Cancelar</button>`);
-  }
-
-  const contactBlock = phoneLine || emailLine ? `${phoneLine}${emailLine}` : '<div class="order-mini-meta text-muted">Sin contacto</div>';
-
-  return `
-    <tr data-id="${order.id ?? ''}">
-      <td>
-        <div><strong>${idLabel}</strong></div>
-        <div class="order-mini-meta">${statusBadge}</div>
-      </td>
-      <td>
-        ${customerName}
-        ${addressLine}
-      </td>
-      <td>
-        ${contactBlock}
-      </td>
-      <td>
-        ${deliveryName}
-        ${deliveryContact}
-        ${assignedLine}
-        ${shippedLine}
-      </td>
-      <td>
-        <span class="${paymentChipClass}">${paymentChipText}</span>
-        ${paymentMethodLine}
-        ${paymentReferenceLine}
-        ${paidLine}
-      </td>
-      <td>${total}</td>
-      <td>
-        <span class="order-mini-meta">Actualizado: ${updatedLabel}</span>
-        ${createdLabel ? `<span class="order-meta-muted">Creado: ${createdLabel}</span>` : ''}
-      </td>
-      <td class="text-right actions-column">
-        ${actions.join(' ')}
-      </td>
-    </tr>
-  `;
+function parseDate(value) {
+  if (!value) return null;
+  const normalized = value.includes('T') ? value : value.replace(' ', 'T');
+  const date = new Date(normalized);
+  if (!Number.isNaN(date.getTime())) return date;
+  const fallback = new Date(value);
+  return Number.isNaN(fallback.getTime()) ? null : fallback;
 }
 
-function renderOrders() {
-  if (!$ordersTbody) return;
-  const searchTerm = ordersState.search.trim().toLowerCase();
-  const statuses = ordersState.statusFilters;
-  const filtered = ordersState.list
-    .filter(order => !statuses.size || statuses.has(order.status))
-    .filter(order => {
-      if (!searchTerm) return true;
-      const haystack = [
-        order.id ? `#${order.id}` : '',
-        order.code || '',
-        order.status_label || '',
-        order.customer?.name || '',
-        order.customer?.address || '',
-        order.customer?.phone || '',
-        order.customer?.email || '',
-        order.payment_method || '',
-        order.delivery?.person?.name || '',
-        order.delivery?.person?.contact || '',
-      ].join(' ').toLowerCase();
-      return haystack.includes(searchTerm);
-    })
-    .sort((a, b) => {
-      const aDate = parseDateValue(a.delivery?.updated_at || a.updated_at || a.delivery?.paid_at || a.delivery?.shipped_at || a.created_at);
-      const bDate = parseDateValue(b.delivery?.updated_at || b.updated_at || b.delivery?.paid_at || b.delivery?.shipped_at || b.created_at);
-      return (bDate?.getTime() || 0) - (aDate?.getTime() || 0);
-    });
-
-  if (!filtered.length) {
-    $ordersTbody.innerHTML = `
-      <tr>
-        <td colspan="8" class="text-center text-muted py-4">No se encontraron pedidos con los filtros seleccionados.</td>
-      </tr>
-    `;
-    return;
-  }
-
-  $ordersTbody.innerHTML = filtered.map(pedidoRowHTML).join('');
+function formatDate(value) {
+  const date = parseDate(value);
+  return date ? dateTime.format(date) : '—';
 }
 
-function setLoadingButton(btn, loading, text = 'Guardando...') {
-  if (!btn) return;
-  if (loading) {
-    if (!btn.dataset.originalHtml) {
-      btn.dataset.originalHtml = btn.innerHTML;
-    }
-    btn.innerHTML = `<span class="spinner-border spinner-border-sm mr-2" role="status" aria-hidden="true"></span>${text}`;
-    btn.disabled = true;
-  } else {
-    if (btn.dataset.originalHtml) {
-      btn.innerHTML = btn.dataset.originalHtml;
-      delete btn.dataset.originalHtml;
-    }
-    btn.disabled = false;
-  }
+function normalizeOrder(raw = {}) {
+  const status = normalizeStatus(raw.status ?? raw.estado ?? raw.estado_gestion ?? '');
+  return {
+    id: raw.id ?? raw.Id ?? null,
+    code: raw.code ?? raw.codigo ?? `#${raw.id ?? raw.Id ?? ''}`,
+    status,
+    status_label: raw.status_label ?? statusLabel(status),
+    total: Number(raw.total ?? raw.Total ?? 0) || 0,
+    payment_method: raw.payment_method ?? raw.metodo_pago ?? null,
+    payment_reference: raw.payment_reference ?? raw.referencia_pago ?? null,
+    coupon_code: raw.coupon_code ?? raw.cupon_codigo ?? null,
+    customer: {
+      name: raw.customer?.name ?? raw.cliente ?? null,
+      email: raw.customer?.email ?? raw.cliente_email ?? null,
+      phone: raw.customer?.phone ?? raw.cliente_telefono ?? null,
+      address: raw.customer?.address ?? raw.cliente_direccion ?? null,
+    },
+    delivery: {
+      person: {
+        name: raw.delivery?.person?.name ?? raw.repartidor_nombre ?? null,
+        contact: raw.delivery?.person?.contact ?? raw.repartidor_contacto ?? null,
+        id: raw.delivery?.person?.id ?? raw.repartidor_id ?? null,
+      },
+      payment_confirmed: Boolean(raw.delivery?.payment_confirmed ?? raw.pago_confirmado ?? false),
+      notes: raw.delivery?.notes ?? raw.notas ?? null,
+      assigned_at: raw.delivery?.assigned_at ?? raw.fecha_asignacion ?? null,
+      shipped_at: raw.delivery?.shipped_at ?? raw.fecha_envio ?? null,
+      paid_at: raw.delivery?.paid_at ?? raw.fecha_pago ?? null,
+      canceled_at: raw.delivery?.canceled_at ?? raw.fecha_cancelacion ?? null,
+      updated_at: raw.delivery?.updated_at ?? raw.actualizado_en ?? raw.gestion_actualizado_en ?? null,
+    },
+    created_at: raw.created_at ?? raw.creado_en ?? null,
+    updated_at: raw.updated_at ?? raw.actualizado_en ?? null,
+    items: Array.isArray(raw.items) ? raw.items : [],
+  };
 }
 
-function showOrdersAlert(type, message) {
+async function fetchOrders(filters = {}) {
+  const params = new URLSearchParams();
+  if (Array.isArray(filters.statuses) && filters.statuses.length) {
+    params.set('status', filters.statuses.join(','));
+  }
+  if (filters.search) {
+    params.set('q', filters.search.trim());
+  }
+  params.set('limit', String(filters.limit ?? 200));
+
+  const res = await fetch(`${ORDERS_ENDPOINT}?${params.toString()}`, {
+    headers: buildHeaders(),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || data.error) {
+    throw new Error(data.error || data.message || 'No se pudieron cargar los pedidos.');
+  }
+  const collection = Array.isArray(data.orders)
+    ? data.orders
+    : Array.isArray(data.data)
+      ? data.data
+      : Array.isArray(data)
+        ? data
+        : [];
+  return collection.map(normalizeOrder);
+}
+
+async function fetchOrderDetail(id) {
+  const res = await fetch(`${ORDERS_ENDPOINT}?id=${encodeURIComponent(id)}&with=items`, {
+    headers: buildHeaders(),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || data.error) {
+    throw new Error(data.error || data.message || 'No se pudo cargar el pedido.');
+  }
+  const order = data.order ?? data.data ?? data;
+  return normalizeOrder(order);
+}
+
+async function updateOrder(id, payload = {}) {
+  const res = await fetch(`${ORDERS_ENDPOINT}?id=${encodeURIComponent(id)}&with=items`, {
+    method: 'PATCH',
+    headers: buildHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify(payload),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || data.error) {
+    throw new Error(data.error || data.message || 'No se pudo actualizar el pedido.');
+  }
+  const order = data.order ?? data.data ?? data;
+  return normalizeOrder(order);
+}
+
+function showOrdersAlert(message, type = 'danger', timeout = 4000) {
   if (!ordersAlert) return;
   ordersAlert.className = `alert alert-${type}`;
   ordersAlert.textContent = message;
   ordersAlert.classList.remove('d-none');
-  if (ordersAlertTimer) {
-    clearTimeout(ordersAlertTimer);
+  if (alertTimer) {
+    clearTimeout(alertTimer);
   }
-  ordersAlertTimer = window.setTimeout(() => {
-    hideOrdersAlert();
-  }, 6000);
+  if (timeout) {
+    alertTimer = window.setTimeout(() => {
+      ordersAlert.classList.add('d-none');
+      alertTimer = null;
+    }, timeout);
+  }
 }
 
 function hideOrdersAlert() {
   if (!ordersAlert) return;
   ordersAlert.classList.add('d-none');
   ordersAlert.textContent = '';
-  if (ordersAlertTimer) {
-    clearTimeout(ordersAlertTimer);
-    ordersAlertTimer = null;
+  if (alertTimer) {
+    clearTimeout(alertTimer);
+    alertTimer = null;
   }
 }
 
-function showOrderModalAlert(message, type = 'danger') {
+function renderOrders() {
+  if (!$ordersTbody) return;
+  if (ordersState.loading) {
+    $ordersTbody.innerHTML = '<tr><td colspan="8" class="text-center text-muted py-4">Cargando pedidos...</td></tr>';
+    return;
+  }
+
+  const search = ordersState.search.trim().toLowerCase();
+  const statuses = ordersState.statusFilters;
+  const filtered = ordersState.list.filter(order => {
+    const statusOk = !statuses.size || statuses.has(order.status);
+    if (!statusOk) return false;
+    if (!search) return true;
+    const haystack = [
+      order.code,
+      order.customer?.name,
+      order.customer?.email,
+      order.customer?.phone,
+      order.delivery?.person?.name,
+      order.delivery?.person?.contact,
+      order.status_label,
+    ].join(' ').toLowerCase();
+    return haystack.includes(search);
+  });
+
+  if (!filtered.length) {
+    $ordersTbody.innerHTML = '<tr><td colspan="8" class="text-center text-muted py-4">No hay pedidos con los filtros seleccionados.</td></tr>';
+    return;
+  }
+
+  $ordersTbody.innerHTML = filtered.map(order => {
+    const deliveryName = order.delivery?.person?.name || 'Sin asignar';
+    const deliveryContact = order.delivery?.person?.contact || '—';
+    const paymentConfirmed = order.delivery?.payment_confirmed;
+    const updatedAt = order.delivery?.updated_at || order.updated_at;
+    const createdAt = order.created_at ? `<span class="order-meta-muted">Creado: ${formatDate(order.created_at)}</span>` : '';
+    const statusBadge = `<span class="status-badge ${statusBadgeClass(order.status)}">${order.status_label}</span>`;
+    const paymentChip = paymentConfirmed
+      ? '<span class="order-payment-chip confirmed">Pago confirmado</span>'
+      : '<span class="order-payment-chip pending">Pago pendiente</span>';
+
+    return `
+      <tr data-id="${order.id}">
+        <td>
+          <strong>${order.code || `#${order.id}`}</strong><br>
+          ${statusBadge}
+          ${createdAt}
+        </td>
+        <td>
+          <strong>${order.customer?.name || 'Sin nombre'}</strong>
+          <span class="order-mini-meta">${order.customer?.address || 'Sin dirección registrada'}</span>
+        </td>
+        <td>
+          <span class="order-mini-meta">Tel: ${order.customer?.phone || '—'}</span>
+          <span class="order-mini-meta">Email: ${order.customer?.email || '—'}</span>
+        </td>
+        <td>
+          <span class="order-delivery-chip ${deliveryName === 'Sin asignar' ? 'unassigned' : ''}">${deliveryName}</span>
+          <span class="order-mini-meta">Contacto: ${deliveryContact}</span>
+        </td>
+        <td>
+          <span class="order-mini-meta">Método: ${order.payment_method || '—'}</span>
+          ${paymentChip}
+        </td>
+        <td>${money.format(order.total)}</td>
+        <td>
+          <span class="order-mini-meta">Actualizado: ${formatDate(updatedAt)}</span>
+        </td>
+        <td class="text-right actions-column">
+          <button class="btn btn-sm btn-primary" data-order-id="${order.id}">
+            Gestionar
+          </button>
+        </td>
+      </tr>
+    `;
+  }).join('');
+}
+
+async function loadOrders({ showLoader = false } = {}) {
+  if (ordersState.loading) return;
+  ordersState.loading = true;
+  if (showLoader && $ordersTbody) {
+    $ordersTbody.innerHTML = '<tr><td colspan="8" class="text-center text-muted py-4">Actualizando pedidos...</td></tr>';
+  }
+  try {
+    hideOrdersAlert();
+    const statuses = Array.from(ordersState.statusFilters);
+    const orders = await fetchOrders({ statuses, search: ordersState.search });
+    ordersState.list = orders;
+    renderOrders();
+  } catch (err) {
+    showOrdersAlert(err.message || 'No se pudieron cargar los pedidos.');
+    if ($ordersTbody) {
+      $ordersTbody.innerHTML = `<tr><td colspan="8" class="text-center text-danger py-4">${err.message || 'Error al cargar pedidos.'}</td></tr>`;
+    }
+  } finally {
+    ordersState.loading = false;
+  }
+}
+
+function resetOrderModal() {
+  currentOrder = null;
+  if (orderModalForm) orderModalForm.reset();
+  if (orderModalAlert) {
+    orderModalAlert.classList.add('d-none');
+    orderModalAlert.textContent = '';
+  }
+  if (orderModalItemsBody) {
+    orderModalItemsBody.innerHTML = '<tr><td colspan="4" class="text-center text-muted py-3">Sin productos.</td></tr>';
+  }
+  if (orderModalTimeline) {
+    orderModalTimeline.innerHTML = '<li class="text-muted">Sin eventos registrados.</li>';
+  }
+}
+
+function fillOrderModal(order) {
+  currentOrder = order;
+  if (!order) return;
+  if (orderModalIdInput) orderModalIdInput.value = order.id ?? '';
+  if (orderModalTitle) orderModalTitle.textContent = `Pedido ${order.code || `#${order.id}`}`;
+  if (orderModalCustomer) orderModalCustomer.textContent = order.customer?.name || 'Sin nombre';
+  if (orderModalContact) orderModalContact.textContent = [order.customer?.email, order.customer?.phone].filter(Boolean).join(' · ') || 'Sin contacto';
+  if (orderModalAddress) orderModalAddress.textContent = order.customer?.address || 'Sin dirección registrada';
+  if (orderModalCode) orderModalCode.textContent = order.code || `#${order.id}`;
+  if (orderModalDate) orderModalDate.textContent = formatDate(order.created_at);
+  if (orderModalPayment) orderModalPayment.textContent = order.payment_method || '—';
+  if (orderModalTotal) orderModalTotal.textContent = money.format(order.total);
+  if (orderStatusSelect) orderStatusSelect.value = order.status;
+  if (orderDeliveryNameInput) orderDeliveryNameInput.value = order.delivery?.person?.name || '';
+  if (orderDeliveryContactInput) orderDeliveryContactInput.value = order.delivery?.person?.contact || '';
+  if (orderPaymentConfirmedInput) orderPaymentConfirmedInput.checked = !!order.delivery?.payment_confirmed;
+  if (orderNotesInput) orderNotesInput.value = order.delivery?.notes || '';
+
+  if (orderModalItemsBody) {
+    if (!order.items || !order.items.length) {
+      orderModalItemsBody.innerHTML = '<tr><td colspan="4" class="text-center text-muted py-3">Sin productos en la orden.</td></tr>';
+    } else {
+      orderModalItemsBody.innerHTML = order.items.map(item => {
+        const quantity = Number(item.quantity ?? item.cantidad ?? 0);
+        const unitPrice = Number(item.unit_price ?? item.precio ?? 0);
+        const lineTotal = Number(item.line_total ?? item.total_linea ?? quantity * unitPrice);
+        return `
+          <tr>
+            <td>${item.product_name || item.nombre || `#${item.product_id}`}</td>
+            <td class="text-right">${quantity}</td>
+            <td class="text-right">${money.format(unitPrice)}</td>
+            <td class="text-right">${money.format(lineTotal)}</td>
+          </tr>
+        `;
+      }).join('');
+    }
+  }
+
+  if (orderModalTimeline) {
+    const timeline = [];
+    if (order.created_at) timeline.push({ label: 'Creado', value: order.created_at });
+    if (order.delivery?.assigned_at) timeline.push({ label: 'Asignado a repartidor', value: order.delivery.assigned_at });
+    if (order.delivery?.shipped_at) timeline.push({ label: 'Enviado', value: order.delivery.shipped_at });
+    if (order.delivery?.paid_at) timeline.push({ label: 'Pago confirmado', value: order.delivery.paid_at });
+    if (order.delivery?.canceled_at) timeline.push({ label: 'Cancelado', value: order.delivery.canceled_at });
+    if (order.delivery?.updated_at) timeline.push({ label: 'Última actualización', value: order.delivery.updated_at });
+
+    if (!timeline.length) {
+      orderModalTimeline.innerHTML = '<li class="text-muted">Sin historial registrado.</li>';
+    } else {
+      orderModalTimeline.innerHTML = timeline.map(entry => `
+        <li>
+          <strong>${entry.label}:</strong>
+          <span class="d-block text-muted">${formatDate(entry.value)}</span>
+        </li>
+      `).join('');
+    }
+  }
+}
+
+function showOrderModalAlert(message) {
   if (!orderModalAlert) return;
-  orderModalAlert.className = `alert alert-${type}`;
   orderModalAlert.textContent = message;
   orderModalAlert.classList.remove('d-none');
 }
@@ -392,170 +453,43 @@ function hideOrderModalAlert() {
   orderModalAlert.textContent = '';
 }
 
-function setOrderModalFetching(isFetching) {
-  if (orderModalSubmitBtn) {
-    setLoadingButton(orderModalSubmitBtn, isFetching, 'Cargando...');
-  }
-  if (orderModalCancelBtn) {
-    orderModalCancelBtn.disabled = isFetching;
-  }
-}
-
-function setOrderModalLoading(isLoading) {
-  if (orderModalSubmitBtn) {
-    setLoadingButton(orderModalSubmitBtn, isLoading, 'Guardando...');
-  }
-  if (orderModalCancelBtn) {
-    orderModalCancelBtn.disabled = isLoading;
-  }
-}
-
-function resetOrderModal() {
-  if (orderModalForm) {
-    orderModalForm.reset();
-    orderModalForm.dataset.orderId = '';
-  }
-  if (orderModalIdInput) orderModalIdInput.value = '';
-  if (orderModalCustomer) orderModalCustomer.textContent = '—';
-  if (orderModalContact) orderModalContact.innerHTML = '<span class="text-muted">Sin contacto</span>';
-  if (orderModalAddress) orderModalAddress.textContent = '—';
-  if (orderModalCode) orderModalCode.textContent = '—';
-  if (orderModalDate) orderModalDate.textContent = '—';
-  if (orderModalPayment) orderModalPayment.textContent = '—';
-  if (orderModalTotal) orderModalTotal.textContent = '—';
-  if (orderModalTimeline) orderModalTimeline.innerHTML = '<li class="text-muted">Cargando...</li>';
+async function openOrderModal(orderId) {
+  resetOrderModal();
+  if (!orderModalElement) return;
+  if (orderModalTitle) orderModalTitle.textContent = 'Cargando pedido...';
   if (orderModalItemsBody) {
     orderModalItemsBody.innerHTML = '<tr><td colspan="4" class="text-center text-muted py-3">Cargando productos...</td></tr>';
   }
-  if (orderModalSubmitBtn && orderModalSubmitBtn.dataset.originalHtml) {
-    setLoadingButton(orderModalSubmitBtn, false);
-  }
-  if (orderModalCancelBtn) orderModalCancelBtn.disabled = false;
-  hideOrderModalAlert();
-}
-
-function fillOrderModal(order, options = {}) {
-  if (!orderModalTitle) return;
-  orderModalTitle.textContent = order.code ? `Orden ${order.code}` : `Orden #${order.id}`;
-  if (orderModalIdInput) orderModalIdInput.value = order.id ?? '';
-  if (orderModalForm) orderModalForm.dataset.orderId = order.id ?? '';
-  if (orderModalCustomer) orderModalCustomer.textContent = order.customer?.name || 'Cliente sin nombre';
-  if (orderModalContact) {
-    const parts = [];
-    if (order.customer?.phone) parts.push(`<div class="order-mini-meta"><i class="fas fa-phone mr-1"></i>${escapeHtml(order.customer.phone)}</div>`);
-    if (order.customer?.email) parts.push(`<div class="order-mini-meta"><i class="fas fa-envelope mr-1"></i>${escapeHtml(order.customer.email)}</div>`);
-    orderModalContact.innerHTML = parts.length ? parts.join('') : '<span class="text-muted">Sin contacto</span>';
-  }
-  if (orderModalAddress) orderModalAddress.textContent = order.customer?.address || 'Sin dirección registrada';
-  if (orderModalCode) orderModalCode.textContent = order.code ? order.code : (order.id ? `#${order.id}` : '—');
-  if (orderModalDate) orderModalDate.textContent = order.created_at ? formatDateTime(order.created_at) : '—';
-  if (orderModalPayment) orderModalPayment.textContent = order.payment_method || '—';
-  if (orderModalTotal) orderModalTotal.textContent = typeof order.total === 'number' && Number.isFinite(order.total) ? money.format(order.total) : '—';
-
-  if (orderStatusSelect) {
-    const preset = options.presetStatus && ['pendiente','enviado','pagado','cancelado'].includes(options.presetStatus)
-      ? options.presetStatus
-      : order.status;
-    orderStatusSelect.value = preset;
-  }
-  if (orderDeliveryNameInput) orderDeliveryNameInput.value = order.delivery?.person?.name || '';
-  if (orderDeliveryContactInput) orderDeliveryContactInput.value = order.delivery?.person?.contact || '';
-  if (orderPaymentConfirmedInput) orderPaymentConfirmedInput.checked = !!order.delivery?.payment_confirmed;
-  if (orderNotesInput) orderNotesInput.value = order.delivery?.notes || '';
-
-  if (orderModalTimeline) {
-    const timeline = [];
-    if (order.created_at) timeline.push({ label: 'Creado', date: order.created_at });
-    if (order.delivery?.assigned_at) timeline.push({ label: 'Repartidor asignado', date: order.delivery.assigned_at, detail: order.delivery?.person?.name ? `a ${order.delivery.person.name}` : '' });
-    if (order.delivery?.shipped_at) timeline.push({ label: 'Enviado', date: order.delivery.shipped_at });
-    if (order.delivery?.paid_at) timeline.push({ label: 'Pago confirmado', date: order.delivery.paid_at });
-    if (order.delivery?.canceled_at) timeline.push({ label: 'Cancelado', date: order.delivery.canceled_at });
-
-    orderModalTimeline.innerHTML = timeline.length
-      ? timeline.map(item => `<li>${escapeHtml(item.label)}${item.detail ? ` <span class="order-meta-muted">${escapeHtml(item.detail)}</span>` : ''}<div class="order-mini-meta">${formatDateTime(item.date)}</div></li>`).join('')
-      : '<li class="text-muted">Sin movimientos registrados.</li>';
-  }
-
-  if (orderModalItemsBody) {
-    const items = Array.isArray(order.items) ? order.items : [];
-    if (!items.length) {
-      orderModalItemsBody.innerHTML = '<tr><td colspan="4" class="text-center text-muted py-3">Sin productos registrados.</td></tr>';
-    } else {
-      orderModalItemsBody.innerHTML = items.map(item => {
-        const productName = item.product_name ? escapeHtml(item.product_name) : (item.product_id ? `#${item.product_id}` : 'Producto');
-        const quantity = item.quantity !== undefined && item.quantity !== null ? numberFormatter.format(item.quantity) : '—';
-        const unitPrice = item.unit_price !== undefined && item.unit_price !== null && Number.isFinite(Number(item.unit_price)) ? money.format(Number(item.unit_price)) : '—';
-        const lineTotalValue = item.line_total !== undefined && item.line_total !== null ? Number(item.line_total) : (item.quantity !== undefined && item.unit_price !== undefined ? Number(item.quantity) * Number(item.unit_price) : NaN);
-        const lineTotal = Number.isFinite(lineTotalValue) ? money.format(lineTotalValue) : '—';
-        return `<tr><td>${productName}</td><td class="text-right">${quantity}</td><td class="text-right">${unitPrice}</td><td class="text-right">${lineTotal}</td></tr>`;
-      }).join('');
-    }
-  }
-
-  if (options.focusField === 'delivery' && orderDeliveryNameInput) {
-    setTimeout(() => orderDeliveryNameInput.focus(), 200);
-  }
-}
-
-async function fetchOrderDetail(orderId) {
-  const params = new URLSearchParams({ id: orderId, with: 'items' });
-  const res = await fetch(`/api/orders.php?${params.toString()}`, {
-    headers: { 'Accept': 'application/json' },
-  });
-  const data = await res.json().catch(() => ({}));
-  if (!res.ok || data.error || !data.order) {
-    throw new Error(data.error || data.message || 'No se encontró la orden solicitada.');
-  }
-  return normalizeOrderFromApi(data.order ?? {});
-}
-
-async function updateOrderStatus(id, payload, { includeItems = false } = {}) {
-  const params = new URLSearchParams();
-  if (includeItems) params.set('with', 'items');
-  const res = await fetch(`/api/orders.php?id=${id}${params.toString() ? `&${params.toString()}` : ''}`, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify(payload),
-  });
-  const data = await res.json().catch(() => ({}));
-  if (!res.ok || data.error) {
-    throw new Error(data.error || data.message || 'No se pudo actualizar el pedido.');
-  }
-  return normalizeOrderFromApi(data.order ?? {});
-}
-
-async function openOrderModal(orderId, options = {}) {
-  if (!orderModalElement) return;
-  resetOrderModal();
-  setOrderModalFetching(true);
-  hideOrdersAlert();
-  orderModal.modal('show');
+  orderModal?.modal('show');
   try {
     const detail = await fetchOrderDetail(orderId);
-    currentOrderDetail = detail;
-    upsertOrder(detail);
-    renderOrders();
-    fillOrderModal(detail, options);
+    fillOrderModal(detail);
   } catch (err) {
-    console.error(err);
-    showOrderModalAlert(err.message || 'No se pudo cargar la orden.');
-  } finally {
-    setOrderModalFetching(false);
+    showOrderModalAlert(err.message || 'No se pudo cargar el pedido.');
   }
 }
 
-async function submitOrderModalUpdate(extra = {}) {
-  if (!currentOrderDetail) return;
-  const id = currentOrderDetail.id;
-  const status = extra.status ?? (orderStatusSelect ? orderStatusSelect.value : currentOrderDetail.status);
-  const deliveryName = (extra.delivery_person !== undefined ? extra.delivery_person : (orderDeliveryNameInput ? orderDeliveryNameInput.value : '')).trim();
-  const deliveryContact = (extra.delivery_contact !== undefined ? extra.delivery_contact : (orderDeliveryContactInput ? orderDeliveryContactInput.value : '')).trim();
-  let paymentConfirmed = extra.payment_confirmed !== undefined ? !!extra.payment_confirmed : !!(orderPaymentConfirmedInput && orderPaymentConfirmedInput.checked);
-  const notes = (extra.notes !== undefined ? extra.notes : (orderNotesInput ? orderNotesInput.value : '')).trim();
+function updateOrderInState(order) {
+  const index = ordersState.list.findIndex(item => item.id === order.id);
+  if (index >= 0) {
+    ordersState.list[index] = order;
+  } else {
+    ordersState.list.unshift(order);
+  }
+}
+
+async function submitOrderModalUpdate({ status: forcedStatus, skipConfirm = false } = {}) {
+  if (!currentOrder) return;
+  const id = currentOrder.id;
+  const status = forcedStatus ?? (orderStatusSelect ? orderStatusSelect.value : currentOrder.status);
+  const deliveryName = orderDeliveryNameInput ? orderDeliveryNameInput.value.trim() : '';
+  const deliveryContact = orderDeliveryContactInput ? orderDeliveryContactInput.value.trim() : '';
+  let paymentConfirmed = orderPaymentConfirmedInput ? orderPaymentConfirmedInput.checked : currentOrder.delivery?.payment_confirmed;
+  const notes = orderNotesInput ? orderNotesInput.value.trim() : '';
 
   if (status === 'enviado' && !deliveryName) {
     showOrderModalAlert('Debes asignar un repartidor antes de marcar la orden como enviada.');
-    if (orderDeliveryNameInput) orderDeliveryNameInput.focus();
+    orderDeliveryNameInput?.focus();
     return;
   }
 
@@ -563,156 +497,70 @@ async function submitOrderModalUpdate(extra = {}) {
     paymentConfirmed = true;
   }
 
-  if (status === 'cancelado' && !extra.skipConfirm) {
-    const confirmed = window.confirm('¿Seguro que deseas cancelar la orden? Se devolverá el inventario de los productos.');
+  if (status === 'cancelado' && !skipConfirm) {
+    const confirmed = window.confirm('¿Seguro que deseas cancelar la orden? Se devolverá el inventario correspondiente.');
     if (!confirmed) return;
   }
 
   hideOrderModalAlert();
-  setOrderModalLoading(true);
+  if (orderModalSubmitBtn) {
+    orderModalSubmitBtn.disabled = true;
+    orderModalSubmitBtn.textContent = 'Guardando...';
+  }
+  orderModalCancelBtn && (orderModalCancelBtn.disabled = true);
 
   try {
-    const updated = await updateOrderStatus(id, {
+    const updated = await updateOrder(id, {
       status,
-      delivery_person: deliveryName || null,
-      delivery_contact: deliveryContact || null,
+      delivery_person: deliveryName,
+      delivery_contact: deliveryContact,
       payment_confirmed: paymentConfirmed,
-      notes: notes || null,
-    }, { includeItems: true });
-
-    currentOrderDetail = updated;
-    upsertOrder(updated);
+      notes,
+    });
+    updateOrderInState(updated);
     renderOrders();
-    fillOrderModal(updated, { presetStatus: status });
-    showOrderModalAlert('Pedido actualizado correctamente.', 'success');
-    hideOrdersAlert();
-    if (status === 'cancelado') {
-      showOrdersAlert('success', 'Pedido cancelado y productos devueltos al inventario.');
-    }
+    fillOrderModal(updated);
+    showOrdersAlert('Pedido actualizado correctamente.', 'success');
   } catch (err) {
-    console.error(err);
     showOrderModalAlert(err.message || 'No se pudo actualizar el pedido.');
   } finally {
-    setOrderModalLoading(false);
+    if (orderModalSubmitBtn) {
+      orderModalSubmitBtn.disabled = false;
+      orderModalSubmitBtn.textContent = 'Guardar cambios';
+    }
+    orderModalCancelBtn && (orderModalCancelBtn.disabled = false);
   }
 }
 
-async function performOrderUpdate(id, payload, { successMessage, confirmMessage, trigger, includeItems = false } = {}) {
-  if (confirmMessage && !window.confirm(confirmMessage)) {
-    return;
-  }
-  if (trigger) setLoadingButton(trigger, true, 'Actualizando...');
-  hideOrdersAlert();
-  try {
-    const updated = await updateOrderStatus(id, payload, { includeItems });
-    upsertOrder(updated);
-    renderOrders();
-    if (currentOrderDetail && currentOrderDetail.id === updated.id) {
-      currentOrderDetail = includeItems ? updated : { ...currentOrderDetail, ...updated, items: currentOrderDetail.items };
-      fillOrderModal(currentOrderDetail);
-      showOrderModalAlert(successMessage || 'Pedido actualizado correctamente.', 'success');
-    } else if (successMessage) {
-      showOrdersAlert('success', successMessage);
-    }
-  } catch (err) {
-    console.error(err);
-    showOrdersAlert('danger', err.message || 'No se pudo actualizar el pedido.');
-    if (currentOrderDetail && currentOrderDetail.id === id) {
-      showOrderModalAlert(err.message || 'No se pudo actualizar el pedido.');
-    }
-  } finally {
-    if (trigger) setLoadingButton(trigger, false);
-  }
+if (orderModalForm) {
+  orderModalForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    submitOrderModalUpdate();
+  });
 }
 
-function handleOrdersTableClick(event) {
-  const btn = event.target.closest('[data-order-action]');
-  if (!btn) return;
-  const id = Number(btn.dataset.orderId);
-  if (!id) return;
-  const action = btn.dataset.orderAction;
-  switch (action) {
-    case 'manage':
-      openOrderModal(id);
-      break;
-    case 'ship':
-      openOrderModal(id, { presetStatus: 'enviado', focusField: 'delivery' });
-      break;
-    case 'mark-paid':
-      performOrderUpdate(id, { status: 'pagado', payment_confirmed: true }, {
-        successMessage: 'Pedido marcado como pagado.',
-        confirmMessage: '¿Confirmar que se recibió el pago de la orden?',
-        trigger: btn,
-        includeItems: currentOrderDetail?.id === id,
-      });
-      break;
-    case 'cancel':
-      performOrderUpdate(id, { status: 'cancelado' }, {
-        successMessage: 'Pedido cancelado y productos devueltos al inventario.',
-        confirmMessage: '¿Seguro que deseas cancelar la orden? Se devolverá el inventario.',
-        trigger: btn,
-        includeItems: currentOrderDetail?.id === id,
-      });
-      break;
-    default:
-      break;
-  }
-}
-
-async function loadPedidos({ showLoader = true } = {}) {
-  if (!$ordersTbody || ordersState.loading) return;
-  ordersState.loading = true;
-  if (showLoader) {
-    renderOrdersLoading();
-  }
-  if (ordersReloadBtn) setLoadingButton(ordersReloadBtn, true, 'Actualizando...');
-  hideOrdersAlert();
-
-  try {
-    const params = new URLSearchParams();
-    if (ordersState.statusFilters.size) {
-      params.set('status', Array.from(ordersState.statusFilters).join(','));
-    }
-    if (ordersState.search.trim()) {
-      params.set('q', ordersState.search.trim());
-    }
-    params.set('limit', '200');
-
-    const res = await fetch(`/api/orders.php${params.toString() ? `?${params.toString()}` : ''}`, {
-      headers: { 'Accept': 'application/json' },
-    });
-    const data = await res.json().catch(() => ({}));
-    if (!res.ok || data.error) {
-      throw new Error(data.error || data.message || 'No se pudo cargar la lista de pedidos.');
-    }
-    const orders = Array.isArray(data.orders)
-      ? data.orders
-      : (Array.isArray(data.data) ? data.data : []);
-    ordersState.list = orders.map(normalizeOrderFromApi);
-    renderOrders();
-  } catch (err) {
-    console.error(err);
-    showOrdersAlert('danger', err.message || 'No se pudo cargar la lista de pedidos.');
-    if (!$ordersTbody.innerHTML.trim()) {
-      $ordersTbody.innerHTML = `<tr><td colspan="8" class="text-center text-danger py-4">${escapeHtml(err.message || 'Error al cargar pedidos.')}</td></tr>`;
-    }
-  } finally {
-    ordersState.loading = false;
-    if (ordersReloadBtn) setLoadingButton(ordersReloadBtn, false);
-  }
+if (orderModalCancelBtn) {
+  orderModalCancelBtn.addEventListener('click', () => {
+    submitOrderModalUpdate({ status: 'cancelado' });
+  });
 }
 
 if ($ordersTbody) {
-  $ordersTbody.addEventListener('click', handleOrdersTableClick);
+  $ordersTbody.addEventListener('click', (event) => {
+    const button = event.target.closest('button[data-order-id]');
+    if (!button) return;
+    const id = button.getAttribute('data-order-id');
+    if (!id) return;
+    openOrderModal(id);
+  });
 }
 
-ordersStatusCheckboxes.forEach(cb => {
-  cb.addEventListener('change', () => {
+ordersStatusCheckboxes.forEach(checkbox => {
+  checkbox.addEventListener('change', () => {
     const selected = new Set();
     ordersStatusCheckboxes.forEach(box => {
-      const value = normalizeStatusValue(box.value);
       if (box.checked) {
-        selected.add(value);
+        selected.add(normalizeStatus(box.value));
       }
     });
     ordersState.statusFilters = selected;
@@ -731,9 +579,9 @@ if (ordersClearBtn) {
   ordersClearBtn.addEventListener('click', () => {
     ordersState.search = '';
     if (ordersSearchInput) ordersSearchInput.value = '';
-    ordersState.statusFilters = new Set(DEFAULT_ORDER_STATUSES);
+    ordersState.statusFilters = new Set(['pendiente', 'enviado']);
     ordersStatusCheckboxes.forEach(box => {
-      box.checked = ordersState.statusFilters.has(normalizeStatusValue(box.value));
+      box.checked = ordersState.statusFilters.has(normalizeStatus(box.value));
     });
     renderOrders();
   });
@@ -741,28 +589,8 @@ if (ordersClearBtn) {
 
 if (ordersReloadBtn) {
   ordersReloadBtn.addEventListener('click', () => {
-    loadPedidos({ showLoader: true });
+    loadOrders({ showLoader: true });
   });
 }
 
-if (orderModalForm) {
-  orderModalForm.addEventListener('submit', (event) => {
-    event.preventDefault();
-    submitOrderModalUpdate();
-  });
-}
-
-if (orderModalCancelBtn) {
-  orderModalCancelBtn.addEventListener('click', () => {
-    submitOrderModalUpdate({ status: 'cancelado' });
-  });
-}
-
-if (orderModalElement) {
-  orderModal.on('hidden.bs.modal', () => {
-    currentOrderDetail = null;
-    resetOrderModal();
-  });
-}
-
-loadPedidos({ showLoader: true });
+loadOrders({ showLoader: true });

--- a/admin.html
+++ b/admin.html
@@ -782,47 +782,87 @@
     
     <script>
 (function guardAdmin() {
-  // token y role guardados por Js/auth.js
-  const token = localStorage.getItem('token');
-  let role = localStorage.getItem('role');
+  const ALLOWED_ROLES = new Set(['admin', 'vendedor']);
 
-  // fallback: extraer rol del JWT si existe
-  function parseJwt(t){
-    try{
-      const base = t.split('.')[1].replace(/-/g,'+').replace(/_/g,'/');
+  function normalizeRoleValue(rawRole) {
+    if (rawRole === null || rawRole === undefined) return '';
+
+    const numericRole = Number(rawRole);
+    if (!Number.isNaN(numericRole) && Number.isFinite(numericRole)) {
+      if (numericRole === 1) return 'admin';
+      if (numericRole === 2) return 'vendedor';
+    }
+
+    const text = rawRole.toString().trim().toLowerCase();
+    if (!text) return '';
+
+    if (['1', 'admin', 'administrator', 'administrador'].includes(text)) {
+      return 'admin';
+    }
+    if (['2', 'vendedor', 'seller', 'ventas', 'salesperson', 'sales'].includes(text)) {
+      return 'vendedor';
+    }
+    return text;
+  }
+
+  function parseJwt(t) {
+    try {
+      const base = t.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
       const json = decodeURIComponent(Array.prototype.map.call(atob(base), c =>
         '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
       ).join(''));
       return JSON.parse(json);
-    }catch{return null;}
+    } catch {
+      return null;
+    }
   }
 
-  if (!role && token) {
-    const p = parseJwt(token);
-    role = p?.role ?? p?.Role ?? p?.rol ?? p?.Rol ?? p?.perfil ?? null;
-    if (role) localStorage.setItem('role', role);
+  const token = localStorage.getItem('token');
+  const storedRole = localStorage.getItem('role');
+  const storedRawRole = localStorage.getItem('role_raw');
+
+  let normalizedRole = normalizeRoleValue(storedRole ?? storedRawRole);
+
+  if ((!normalizedRole || !ALLOWED_ROLES.has(normalizedRole)) && token) {
+    const payload = parseJwt(token);
+    const jwtRole = payload?.role ?? payload?.Role ?? payload?.rol ?? payload?.Rol ?? payload?.perfil ?? null;
+    if (jwtRole !== null && jwtRole !== undefined) {
+      localStorage.setItem('role_raw', jwtRole);
+      normalizedRole = normalizeRoleValue(jwtRole);
+    }
   }
 
-  // si no hay token o no es admin -> al login
-  if (!token || role !== 'admin') {
+  if (!token || !ALLOWED_ROLES.has(normalizedRole)) {
     localStorage.removeItem('token');
     localStorage.removeItem('role');
+    localStorage.removeItem('role_raw');
     localStorage.removeItem('name');
     localStorage.removeItem('email');
     window.location.replace('login.html');
     return;
   }
 
-  // pinta nombre/email si están guardados
+  const normalized = normalizedRole || 'admin';
+  localStorage.setItem('role', normalized);
+  window.__DASHBOARD_ROLE = normalized;
+
+  if (document.body) {
+    document.body.setAttribute('data-role', normalized);
+    document.body.classList.add(`role-${normalized}`);
+  }
+
+  const isAdmin = normalized === 'admin';
   const nameEl = document.getElementById('adminName');
   const emailEl = document.getElementById('adminEmail');
-  if (nameEl)  nameEl.textContent  = localStorage.getItem('name')  || nameEl.textContent;
-  if (emailEl) emailEl.textContent = localStorage.getItem('email') || emailEl.textContent;
+  const storedName = localStorage.getItem('name');
+  const storedEmail = localStorage.getItem('email');
+  if (nameEl && storedName) nameEl.textContent = storedName;
+  if (emailEl && storedEmail) emailEl.textContent = storedEmail;
 
   const badge = document.getElementById('sessionBadge');
-  if (badge) badge.textContent = 'Sesión activa (admin)';
+  if (badge) badge.textContent = isAdmin ? 'Sesión activa (admin)' : 'Sesión activa (ventas)';
 })();
-</script>
+    </script>
 
     
     
@@ -1537,26 +1577,69 @@
     const toggleBtn = document.getElementById('menuToggle');
     const navButtons = document.querySelectorAll('.nav-btn');
     const sections = document.querySelectorAll('.content-section');
+    const dashboardRole = window.__DASHBOARD_ROLE || 'admin';
+    const isVendorView = dashboardRole === 'vendedor';
+    const vendorAllowedSections = new Set(['sales', 'products']);
+
+    function isSectionAllowed(sectionName) {
+      if (!isVendorView) return true;
+      return vendorAllowedSections.has(sectionName);
+    }
 
     function showSection(sectionName) {
+      const desired = sectionName && isSectionAllowed(sectionName)
+        ? sectionName
+        : (isVendorView ? 'sales' : 'dashboard');
+
       navButtons.forEach(btn => {
-        const matches = btn.dataset.section === sectionName;
+        const matches = btn.dataset.section === desired;
         btn.classList.toggle('active', matches);
       });
 
       sections.forEach(section => {
-        section.classList.toggle('active', section.id === `section-${sectionName}`);
+        const sectionKey = section.id.replace('section-', '');
+        const shouldDisplay = sectionKey === desired;
+        section.classList.toggle('active', shouldDisplay);
+        if (isVendorView) {
+          section.classList.toggle('d-none', !isSectionAllowed(sectionKey));
+        }
       });
+
+      if (location.hash.replace('#', '') !== desired) {
+        if (typeof history.replaceState === 'function') {
+          history.replaceState({}, '', `#${desired}`);
+        } else {
+          location.hash = `#${desired}`;
+        }
+      }
     }
 
     navButtons.forEach(btn => {
+      const sectionName = btn.dataset.section;
+      if (!isSectionAllowed(sectionName)) {
+        btn.classList.add('d-none');
+        btn.setAttribute('aria-hidden', 'true');
+        btn.tabIndex = -1;
+        return;
+      }
+
       btn.addEventListener('click', () => {
-        showSection(btn.dataset.section);
+        showSection(sectionName);
         if (window.innerWidth < 992) {
           layout.classList.add('sidebar-hidden');
         }
       });
     });
+
+    if (isVendorView) {
+      sections.forEach(section => {
+        const sectionKey = section.id.replace('section-', '');
+        if (!isSectionAllowed(sectionKey)) {
+          section.classList.remove('active');
+          section.classList.add('d-none');
+        }
+      });
+    }
 
     toggleBtn.addEventListener('click', () => {
       layout.classList.toggle('sidebar-hidden');
@@ -1582,6 +1665,12 @@
     if (storedName) {
       document.getElementById('adminName').textContent = storedName;
     }
+
+    const hashSection = location.hash.replace('#', '');
+    const initialSection = hashSection && isSectionAllowed(hashSection)
+      ? hashSection
+      : (isVendorView ? 'sales' : 'dashboard');
+    showSection(initialSection);
   </script>
 
   <script>
@@ -2003,6 +2092,7 @@
       localStorage.removeItem(k);
       sessionStorage.removeItem(k);
     }
+    ['role', 'role_raw', 'name', 'email'].forEach(key => localStorage.removeItem(key));
   }
   // Decodificar payload de JWT sin librerías
   function parseJwt(token) {
@@ -2066,7 +2156,9 @@
   <script type="module" src="Js/settings.js"></script>
   <script type="module">
   // ======= CONFIG API =======
-  const API_BASE = 'https://joyeria-full-stack-production.up.railway.app';
+  const API_BASE = '';
+  const PRODUCTS_ENDPOINT = '/api/products.php';
+  const PRODUCT_IMAGE_ENDPOINT = '/api/product-image.php';
 
   // ======= Auth helpers =======
   const TOKEN_KEYS = ['auth_token', 'token', 'jwt', 'api_key'];
@@ -2087,9 +2179,24 @@
     }
     return h;
   }
+  function resolveApiPath(path) {
+    if (!path) return path;
+    if (path.startsWith('http')) return path;
+    if (path.startsWith('/api/products/')) {
+      const id = path.slice('/api/products/'.length).replace(/\/?$/, '');
+      if (id) return `${PRODUCTS_ENDPOINT}?id=${encodeURIComponent(id)}`;
+      return PRODUCTS_ENDPOINT;
+    }
+    if (path === '/api/products') {
+      return PRODUCTS_ENDPOINT;
+    }
+    return path;
+  }
+
   async function apiFetch(url, opts = {}) {
     const headers = authHeaders(opts.headers || {});
-    const res = await fetch(url, { ...opts, headers });
+    const resolved = resolveApiPath(url);
+    const res = await fetch(resolved, { ...opts, headers });
     const text = await res.text().catch(()=> '');
     if (!res.ok) {
       // intenta parsear json para mensaje fino
@@ -2109,6 +2216,8 @@
   const tblBody    = $('#tblProductos tbody');
   const frm        = $('#frmProducto');
   const modalTitle = $('#modalTitle');
+  const dashboardRole = window.__DASHBOARD_ROLE || 'admin';
+  const isAdminDashboard = dashboardRole === 'admin';
 
   // Campos modal
   const fId        = $('#p_id');
@@ -2128,20 +2237,31 @@
     `;
     try {
       // si este GET también requiere token, ya usamos apiFetch
-      const data = await apiFetch(`${API_BASE}/api/products`);
-      if (!Array.isArray(data) || data.length === 0) {
+      const data = await apiFetch('/api/products');
+      const list = Array.isArray(data)
+        ? data
+        : Array.isArray(data.products)
+          ? data.products
+          : [];
+      if (!list.length) {
         tblBody.innerHTML = `
           <tr><td colspan="7" class="text-center text-muted">Sin productos.</td></tr>
         `;
         return;
       }
-      tblBody.innerHTML = data.map(p => {
+      tblBody.innerHTML = list.map(p => {
         const id     = p.Id ?? p.id;
         const codigo = p.Codigo ?? p.codigo ?? '';
         const nombre = p.Nombre ?? p.nombre ?? '';
         const precio = Number(p.Precio ?? p.precio ?? 0);
         const stock  = Number(p.Stock ?? p.stock ?? 0);
         const activo = Number(p.Activo ?? p.activo ?? 0);
+        const actionsHtml = isAdminDashboard
+          ? `
+              <button class="btn btn-sm btn-outline-primary" data-edit="${id}">Editar</button>
+              <button class="btn btn-sm btn-outline-danger" data-del="${id}">Eliminar</button>
+            `
+          : '<span class="text-muted">Solo lectura</span>';
         return `
           <tr data-id="${id}">
             <td>${id}</td>
@@ -2154,10 +2274,7 @@
                 ${activo ? 'Sí' : 'No'}
               </span>
             </td>
-            <td class="text-right">
-              <button class="btn btn-sm btn-outline-primary" data-edit="${id}">Editar</button>
-              <button class="btn btn-sm btn-outline-danger"  data-del="${id}">Eliminar</button>
-            </td>
+            <td class="text-right">${actionsHtml}</td>
           </tr>
         `;
       }).join('');
@@ -2171,59 +2288,73 @@
     }
   }
 
-  // ========= NUEVO =========
-  document.querySelector('[data-target="#modalProducto"]')
-    ?.addEventListener('click', () => {
+  const newProductBtn = document.querySelector('[data-target="#modalProducto"]');
+  if (!isAdminDashboard && newProductBtn) {
+    newProductBtn.classList.add('d-none');
+    newProductBtn.setAttribute('aria-hidden', 'true');
+    newProductBtn.tabIndex = -1;
+  }
+
+  if (isAdminDashboard) {
+    // ========= NUEVO =========
+    newProductBtn?.addEventListener('click', () => {
       frm.reset();
       fId.value = '';
       modalTitle.textContent = 'Nuevo producto';
     });
 
-  // ========= EDITAR / ELIMINAR =========
-  document.getElementById('section-products')
-    .addEventListener('click', async (e) => {
-      const btn = e.target.closest('button');
-      if (!btn) return;
+    // ========= EDITAR / ELIMINAR =========
+    document.getElementById('section-products')
+      ?.addEventListener('click', async (e) => {
+        const btn = e.target.closest('button');
+        if (!btn) return;
 
-      // --- Editar ---
-      if (btn.dataset.edit) {
-        const id = btn.dataset.edit;
-        try {
-          const p = await apiFetch(`${API_BASE}/api/products/${id}`);
+        // --- Editar ---
+        if (btn.dataset.edit) {
+          const id = btn.dataset.edit;
+          try {
+            const data = await apiFetch(`/api/products/${id}`);
+            const p = data.product ?? data;
 
-          fId.value        = p.Id ?? id;
-          fCodigo.value    = p.Codigo ?? p.codigo ?? '';
-          fNombre.value    = p.Nombre ?? p.nombre ?? '';
-          fPrecio.value    = Number(p.Precio ?? p.precio ?? 0).toFixed(2);
-          fStock.value     = Number(p.Stock ?? p.stock ?? 0);
-          fActivo.value    = Number(p.Activo ?? p.activo ?? 0);
-          fCategoria.value = p.Categoria ?? p.categoria ?? '';
-          fMaterial.value  = p.Material ?? p.material ?? '';
-          fImagen.value    = p.ImagenUrl ?? p.imagenurl ?? p.imagenUrl ?? '';
+            fId.value        = p.Id ?? id;
+            fCodigo.value    = p.Codigo ?? p.codigo ?? '';
+            fNombre.value    = p.Nombre ?? p.nombre ?? '';
+            fPrecio.value    = Number(p.Precio ?? p.precio ?? 0).toFixed(2);
+            fStock.value     = Number(p.Stock ?? p.stock ?? 0);
+            fActivo.value    = Number(p.Activo ?? p.activo ?? 0);
+            fCategoria.value = p.Categoria ?? p.categoria ?? '';
+            fMaterial.value  = p.Material ?? p.material ?? '';
+            fImagen.value    = p.ImagenUrl ?? p.imagenurl ?? p.imagenUrl ?? '';
 
-          modalTitle.textContent = 'Editar producto';
-          window.jQuery?.('#modalProducto').modal('show');
-        } catch (err) {
-          alert(err.message || 'No se pudo cargar el producto');
+            modalTitle.textContent = 'Editar producto';
+            window.jQuery?.('#modalProducto').modal('show');
+          } catch (err) {
+            alert(err.message || 'No se pudo cargar el producto');
+          }
         }
-      }
 
-      // --- Eliminar ---
-      if (btn.dataset.del) {
-        const id = btn.dataset.del;
-        if (!confirm('¿Eliminar producto #' + id + '?')) return;
-        try {
-          await apiFetch(`${API_BASE}/api/products/${id}`, { method: 'DELETE' });
-          await loadProductos();
-        } catch (err) {
-          alert(err.message || 'Error al eliminar');
+        // --- Eliminar ---
+        if (btn.dataset.del) {
+          const id = btn.dataset.del;
+          if (!confirm('¿Eliminar producto #' + id + '?')) return;
+          try {
+            await apiFetch(`/api/products/${id}`, { method: 'DELETE' });
+            await loadProductos();
+          } catch (err) {
+            alert(err.message || 'Error al eliminar');
+          }
         }
-      }
-    });
+      });
+  }
 
   // ========= GUARDAR (crear/actualizar) =========
-  frm.addEventListener('submit', async (ev) => {
+  frm?.addEventListener('submit', async (ev) => {
     ev.preventDefault();
+
+    if (!isAdminDashboard) {
+      alert('No tienes permisos para modificar productos.');
+      return;
+    }
 
     const precio = parseFloat(fPrecio.value || '0');
     const stock  = parseInt(fStock.value || '0', 10);
@@ -2253,7 +2384,7 @@
     };
 
     const id = fId.value.trim();
-    const url = id ? `${API_BASE}/api/products/${id}` : `${API_BASE}/api/products`;
+    const url = id ? `/api/products/${id}` : '/api/products';
     const method = id ? 'PUT' : 'POST';
 
     try {

--- a/api/categories.php
+++ b/api/categories.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+header('Content-Type: application/json; charset=utf-8');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With');
+header('Access-Control-Max-Age: 86400');
+
+require __DIR__ . '/db.php';
+require __DIR__ . '/products-lib.php';
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+if ($method === 'OPTIONS') {
+    respond_json(204);
+}
+
+if ($method !== 'GET') {
+    respond_error(405, 'Método no permitido.');
+}
+
+try {
+    $productSchema = ensure_products_schema($pdo);
+} catch (Throwable $e) {
+    respond_error(500, 'No se pudo preparar el servicio de categorías.', ['detail' => $e->getMessage()]);
+}
+
+$column = $productSchema['category'];
+if (!$column) {
+    respond_json(200, ['ok' => true, 'categories' => []]);
+}
+
+$sql = 'SELECT DISTINCT ' . $column . ' AS categoria FROM ' . $productSchema['table'] . ' WHERE ' . $column . ' IS NOT NULL AND TRIM(' . $column . ") <> '' ORDER BY " . $column;
+$stmt = $pdo->query($sql);
+$rows = $stmt ? $stmt->fetchAll(PDO::FETCH_COLUMN) : [];
+
+$categories = [];
+foreach ($rows as $row) {
+    $text = trim((string) $row);
+    if ($text !== '' && !in_array($text, $categories, true)) {
+        $categories[] = $text;
+    }
+}
+
+respond_json(200, ['ok' => true, 'categories' => $categories]);

--- a/api/login.php
+++ b/api/login.php
@@ -44,13 +44,17 @@ switch ((int)$u['rol_id']) {
 // token simple (si quieres algo más fuerte, crea tabla sesiones)
 $token = bin2hex(random_bytes(16));
 
-echo json_encode([
+$response = [
   'ok' => true,
   'token' => $token,
   'user' => [
-    'id'     => (int)$u['usuario_id'],
-    'nombre' => $u['nombre'],
-    'email'  => $u['email'],
-    'role'   => $role,
-  ]
-]);
+    'id'       => (int) $u['usuario_id'],
+    'nombre'   => $u['nombre'],
+    'email'    => $u['email'],
+    'role'     => $role,
+    'role_id'  => (int) $u['rol_id'],
+    'estado'   => (int) $u['estado'],
+  ],
+];
+
+echo json_encode($response, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);

--- a/api/product-image.php
+++ b/api/product-image.php
@@ -1,0 +1,153 @@
+<?php
+declare(strict_types=1);
+
+header('Content-Type: application/json; charset=utf-8');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With');
+header('Access-Control-Max-Age: 86400');
+
+require __DIR__ . '/db.php';
+require __DIR__ . '/products-lib.php';
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+if ($method === 'OPTIONS') {
+    respond_json(204);
+}
+
+if ($method !== 'POST') {
+    respond_error(405, 'Método no permitido. Usa POST.');
+}
+
+try {
+    $productSchema = ensure_products_schema($pdo);
+    $imageSchema = ensure_images_schema($pdo, $productSchema);
+} catch (Throwable $e) {
+    respond_error(500, 'No se pudo preparar el servicio de imágenes.', ['detail' => $e->getMessage()]);
+}
+
+$productId = isset($_POST['product_id']) ? (int) $_POST['product_id'] : (isset($_GET['product_id']) ? (int) $_GET['product_id'] : 0);
+if ($productId <= 0) {
+    respond_error(400, 'Falta el identificador del producto.');
+}
+
+$product = fetch_product_row($pdo, $productSchema, $imageSchema, $productId);
+if (!$product) {
+    respond_error(404, 'Producto no encontrado.');
+}
+
+if (!isset($_FILES['file'])) {
+    respond_error(400, 'No se recibió ningún archivo.');
+}
+
+$file = $_FILES['file'];
+if (!is_array($file) || ($file['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
+    $errorCode = $file['error'] ?? UPLOAD_ERR_NO_FILE;
+    $messages = [
+        UPLOAD_ERR_INI_SIZE => 'El archivo excede el tamaño permitido por el servidor.',
+        UPLOAD_ERR_FORM_SIZE => 'El archivo excede el tamaño permitido por el formulario.',
+        UPLOAD_ERR_PARTIAL => 'El archivo se subió de forma incompleta.',
+        UPLOAD_ERR_NO_FILE => 'No se seleccionó ningún archivo.',
+        UPLOAD_ERR_NO_TMP_DIR => 'Falta la carpeta temporal en el servidor.',
+        UPLOAD_ERR_CANT_WRITE => 'No se pudo guardar el archivo en disco.',
+        UPLOAD_ERR_EXTENSION => 'Una extensión bloqueó la carga del archivo.',
+    ];
+    $message = $messages[$errorCode] ?? 'Error al subir la imagen.';
+    respond_error(400, $message, ['code' => $errorCode]);
+}
+
+$tmpPath = $file['tmp_name'] ?? null;
+if (!$tmpPath || !is_uploaded_file($tmpPath)) {
+    respond_error(400, 'El archivo subido no es válido.');
+}
+
+$size = (int) ($file['size'] ?? 0);
+$maxBytes = 5 * 1024 * 1024; // 5 MB
+if ($size > $maxBytes) {
+    respond_error(413, 'La imagen es demasiado grande. Máximo 5 MB.');
+}
+
+$binary = file_get_contents($tmpPath);
+if ($binary === false || $binary === '') {
+    respond_error(400, 'No se pudo leer el archivo subido.');
+}
+
+$finfo = new finfo(FILEINFO_MIME_TYPE);
+$mime = $finfo->file($tmpPath) ?: ($file['type'] ?? 'application/octet-stream');
+if (strpos($mime, 'image/') !== 0) {
+    respond_error(415, 'Solo se permiten archivos de imagen.');
+}
+
+$filename = $file['name'] ?? null;
+
+try {
+    $pdo->beginTransaction();
+
+    $existing = null;
+    if (!empty($imageSchema['table'])) {
+        $stmt = $pdo->prepare(
+            'SELECT ' . $imageSchema['id'] . ' AS imagen_id
+             FROM ' . $imageSchema['table'] . '
+             WHERE ' . $imageSchema['product_fk'] . ' = :id
+             ORDER BY ' . $imageSchema['id'] . ' ASC
+             LIMIT 1'
+        );
+        $stmt->execute([':id' => $productId]);
+        $existing = $stmt->fetch();
+    }
+
+    if ($existing && isset($existing['imagen_id'])) {
+        $stmt = $pdo->prepare(
+            'UPDATE ' . $imageSchema['table'] . '
+             SET ' . $imageSchema['blob'] . ' = :blob,
+                 ' . $imageSchema['mime'] . ' = :mime,
+                 ' . $imageSchema['url'] . ' = NULL,
+                 ' . $imageSchema['filename'] . ' = :filename
+             WHERE ' . $imageSchema['id'] . ' = :id'
+        );
+        $stmt->execute([
+            ':blob' => $binary,
+            ':mime' => $mime,
+            ':filename' => $filename,
+            ':id' => $existing['imagen_id'],
+        ]);
+        $imageId = (int) $existing['imagen_id'];
+    } else {
+        $stmt = $pdo->prepare(
+            'INSERT INTO ' . $imageSchema['table'] . ' (' . $imageSchema['product_fk'] . ', ' . $imageSchema['blob'] . ', ' . $imageSchema['mime'] . ', ' . $imageSchema['url'] . ', ' . $imageSchema['filename'] . ')
+             VALUES (:product_id, :blob, :mime, NULL, :filename)'
+        );
+        $stmt->execute([
+            ':product_id' => $productId,
+            ':blob' => $binary,
+            ':mime' => $mime,
+            ':filename' => $filename,
+        ]);
+        $imageId = (int) $pdo->lastInsertId();
+    }
+
+    $dataUrl = build_data_url($mime, $binary, null);
+    if (!empty($productSchema['image']) && $dataUrl !== null) {
+        $stmt = $pdo->prepare(
+            'UPDATE ' . $productSchema['table'] . ' SET ' . $productSchema['image'] . ' = :url WHERE ' . $productSchema['id'] . ' = :id'
+        );
+        $stmt->execute([
+            ':url' => $dataUrl,
+            ':id' => $productId,
+        ]);
+    }
+
+    $pdo->commit();
+} catch (Throwable $e) {
+    $pdo->rollBack();
+    respond_error(500, 'No se pudo guardar la imagen.', ['detail' => $e->getMessage()]);
+}
+
+respond_json(200, [
+    'ok' => true,
+    'product_id' => $productId,
+    'image_id' => $imageId,
+    'mime' => $mime,
+    'size' => $size,
+    'url' => $dataUrl,
+]);

--- a/api/products-lib.php
+++ b/api/products-lib.php
@@ -1,0 +1,441 @@
+<?php
+declare(strict_types=1);
+
+function respond_json(int $status, array $payload = []): void
+{
+    http_response_code($status);
+    if ($status === 204) {
+        exit;
+    }
+    echo json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+function respond_error(int $status, string $message, array $extra = []): void
+{
+    $payload = array_merge(['error' => $message], $extra);
+    respond_json($status, $payload);
+}
+
+function read_json_input(): array
+{
+    $raw = file_get_contents('php://input');
+    if ($raw === false || $raw === '') {
+        return [];
+    }
+    $data = json_decode($raw, true);
+    if (json_last_error() !== JSON_ERROR_NONE || !is_array($data)) {
+        return [];
+    }
+    return $data;
+}
+
+function table_exists(PDO $pdo, string $table): bool
+{
+    $stmt = $pdo->prepare(
+        'SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :table'
+    );
+    $stmt->execute([':table' => $table]);
+    return (int) $stmt->fetchColumn() > 0;
+}
+
+function column_exists(PDO $pdo, string $table, string $column): bool
+{
+    $stmt = $pdo->prepare(
+        'SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :table AND COLUMN_NAME = :column'
+    );
+    $stmt->execute([
+        ':table' => $table,
+        ':column' => $column,
+    ]);
+    return (int) $stmt->fetchColumn() > 0;
+}
+
+function detect_table(PDO $pdo, array $candidates): ?string
+{
+    foreach ($candidates as $candidate) {
+        if (table_exists($pdo, $candidate)) {
+            return $candidate;
+        }
+    }
+    return null;
+}
+
+function detect_column(PDO $pdo, string $table, array $candidates): ?string
+{
+    foreach ($candidates as $candidate) {
+        if (column_exists($pdo, $table, $candidate)) {
+            return $candidate;
+        }
+    }
+    return null;
+}
+
+function ensure_products_schema(PDO $pdo): array
+{
+    $schema = [
+        'table' => null,
+        'id' => null,
+        'code' => null,
+        'name' => null,
+        'price' => null,
+        'stock' => null,
+        'active' => null,
+        'category' => null,
+        'material' => null,
+        'image' => null,
+        'description' => null,
+    ];
+
+    $schema['table'] = detect_table($pdo, ['producto', 'productos', 'articulo', 'articulos', 'product', 'products']);
+    if (!$schema['table']) {
+        respond_error(500, 'No se encontró la tabla de productos.');
+    }
+
+    $table = $schema['table'];
+    $schema['id'] = detect_column($pdo, $table, ['producto_id', 'id', 'product_id', 'articulo_id']);
+    if (!$schema['id']) {
+        respond_error(500, 'No se encontró la columna de identificador de productos.');
+    }
+
+    $schema['code'] = detect_column($pdo, $table, ['codigo', 'sku', 'clave', 'code']);
+    $schema['name'] = detect_column($pdo, $table, ['nombre', 'titulo', 'name', 'descripcion']);
+    $schema['price'] = detect_column($pdo, $table, ['precio', 'price', 'costo']);
+    $schema['stock'] = detect_column($pdo, $table, ['stock', 'existencia', 'existencias', 'cantidad']);
+    $schema['active'] = detect_column($pdo, $table, ['activo', 'estado', 'estatus', 'habilitado']);
+    $schema['category'] = detect_column($pdo, $table, ['categoria', 'categoria_id', 'category', 'categoria_nombre']);
+    $schema['material'] = detect_column($pdo, $table, ['material', 'material_id', 'material_nombre']);
+    $schema['image'] = detect_column($pdo, $table, ['imagen', 'imagen_url', 'imagenurl', 'image', 'image_url', 'url_imagen']);
+    $schema['description'] = detect_column($pdo, $table, ['descripcion', 'description', 'detalle']);
+
+    return $schema;
+}
+
+function ensure_images_schema(PDO $pdo, array $productSchema): array
+{
+    $schema = [
+        'table' => detect_table($pdo, ['imagenes_producto', 'imagen_producto', 'producto_imagen', 'producto_imagenes', 'product_images', 'product_image', 'imagenes', 'imagen']),
+        'id' => null,
+        'product_fk' => null,
+        'url' => null,
+        'blob' => null,
+        'mime' => null,
+        'filename' => null,
+        'created_at' => null,
+    ];
+
+    if (!$schema['table']) {
+        $schema['table'] = 'imagenes_producto';
+        $pdo->exec(
+            'CREATE TABLE IF NOT EXISTS imagenes_producto (
+                imagen_id INT NOT NULL AUTO_INCREMENT,
+                producto_id INT NOT NULL,
+                url TEXT NULL,
+                imagen_blob LONGBLOB NULL,
+                mime_type VARCHAR(120) NULL,
+                nombre_archivo VARCHAR(255) NULL,
+                creado_en TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (imagen_id),
+                INDEX idx_producto (producto_id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'
+        );
+    }
+
+    $table = $schema['table'];
+    $schema['id'] = detect_column($pdo, $table, ['imagen_id', 'id', 'image_id']);
+    if (!$schema['id']) {
+        $schema['id'] = 'imagen_id';
+        if (!column_exists($pdo, $table, $schema['id'])) {
+            $pdo->exec('ALTER TABLE ' . $table . ' ADD COLUMN imagen_id INT NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST');
+        }
+    }
+
+    $schema['product_fk'] = detect_column($pdo, $table, ['producto_id', 'product_id', 'articulo_id', 'id_producto']);
+    if (!$schema['product_fk']) {
+        $schema['product_fk'] = 'producto_id';
+        if (!column_exists($pdo, $table, $schema['product_fk'])) {
+            $pdo->exec('ALTER TABLE ' . $table . ' ADD COLUMN ' . $schema['product_fk'] . ' INT NOT NULL');
+            $pdo->exec('CREATE INDEX IF NOT EXISTS idx_producto_fk ON ' . $table . ' (' . $schema['product_fk'] . ')');
+        }
+    }
+
+    $schema['url'] = detect_column($pdo, $table, ['url', 'ruta', 'path', 'enlace']);
+    if (!$schema['url']) {
+        $schema['url'] = 'url';
+        if (!column_exists($pdo, $table, $schema['url'])) {
+            $pdo->exec('ALTER TABLE ' . $table . ' ADD COLUMN ' . $schema['url'] . ' TEXT NULL');
+        }
+    }
+
+    $schema['blob'] = detect_column($pdo, $table, ['imagen_blob', 'blob', 'contenido', 'data']);
+    if (!$schema['blob']) {
+        $schema['blob'] = 'imagen_blob';
+        if (!column_exists($pdo, $table, $schema['blob'])) {
+            $pdo->exec('ALTER TABLE ' . $table . ' ADD COLUMN ' . $schema['blob'] . ' LONGBLOB NULL');
+        }
+    }
+
+    $schema['mime'] = detect_column($pdo, $table, ['mime_type', 'mime', 'tipo_contenido']);
+    if (!$schema['mime']) {
+        $schema['mime'] = 'mime_type';
+        if (!column_exists($pdo, $table, $schema['mime'])) {
+            $pdo->exec('ALTER TABLE ' . $table . ' ADD COLUMN ' . $schema['mime'] . ' VARCHAR(120) NULL');
+        }
+    }
+
+    $schema['filename'] = detect_column($pdo, $table, ['nombre_archivo', 'filename', 'archivo']);
+    if (!$schema['filename']) {
+        $schema['filename'] = 'nombre_archivo';
+        if (!column_exists($pdo, $table, $schema['filename'])) {
+            $pdo->exec('ALTER TABLE ' . $table . ' ADD COLUMN ' . $schema['filename'] . ' VARCHAR(255) NULL');
+        }
+    }
+
+    $schema['created_at'] = detect_column($pdo, $table, ['creado_en', 'created_at', 'fecha_creacion']);
+    if (!$schema['created_at']) {
+        $schema['created_at'] = 'creado_en';
+        if (!column_exists($pdo, $table, $schema['created_at'])) {
+            $pdo->exec('ALTER TABLE ' . $table . ' ADD COLUMN ' . $schema['created_at'] . ' TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP');
+        }
+    }
+
+    if (!empty($productSchema['table']) && !empty($productSchema['id'])) {
+        $fkName = 'fk_' . $schema['table'] . '_' . $productSchema['table'];
+        try {
+            $pdo->exec(
+                'ALTER TABLE ' . $schema['table'] . ' ADD CONSTRAINT ' . $fkName .
+                ' FOREIGN KEY (' . $schema['product_fk'] . ') REFERENCES ' . $productSchema['table'] . '(' . $productSchema['id'] . ')
+                 ON DELETE CASCADE ON UPDATE CASCADE'
+            );
+        } catch (Throwable $e) {
+            // Ignorar si ya existe
+        }
+    }
+
+    return $schema;
+}
+
+function build_data_url(?string $mime, ?string $blob, ?string $fallbackUrl = null): ?string
+{
+    if ($blob !== null && $blob !== '') {
+        $type = $mime ?: 'image/jpeg';
+        $base64 = base64_encode($blob);
+        return 'data:' . $type . ';base64,' . $base64;
+    }
+    if ($fallbackUrl !== null && $fallbackUrl !== '') {
+        return $fallbackUrl;
+    }
+    return null;
+}
+
+function map_product_row(array $row, array $productSchema, ?array $imageRow = null): array
+{
+    $idKey = $productSchema['id'];
+    $codeKey = $productSchema['code'];
+    $nameKey = $productSchema['name'];
+    $priceKey = $productSchema['price'];
+    $stockKey = $productSchema['stock'];
+    $activeKey = $productSchema['active'];
+    $categoryKey = $productSchema['category'];
+    $materialKey = $productSchema['material'];
+    $imageKey = $productSchema['image'];
+    $descriptionKey = $productSchema['description'];
+
+    $id = isset($row[$idKey]) ? (int) $row[$idKey] : null;
+
+    $price = null;
+    if ($priceKey && isset($row[$priceKey]) && is_numeric($row[$priceKey])) {
+        $price = (float) $row[$priceKey];
+    }
+
+    $stock = null;
+    if ($stockKey && isset($row[$stockKey]) && $row[$stockKey] !== null && $row[$stockKey] !== '') {
+        $stock = (int) $row[$stockKey];
+    }
+
+    $active = 1;
+    if ($activeKey && array_key_exists($activeKey, $row)) {
+        $value = $row[$activeKey];
+        if (is_numeric($value)) {
+            $active = (int) $value ? 1 : 0;
+        } else {
+            $text = strtolower(trim((string) $value));
+            $active = in_array($text, ['1', 'true', 'activo', 'habilitado', 'disponible', 'yes', 'si'], true) ? 1 : 0;
+        }
+    }
+
+    $imageUrl = null;
+    if ($imageRow) {
+        $imageUrl = build_data_url($imageRow['mime'] ?? null, $imageRow['blob'] ?? null, $imageRow['url'] ?? null);
+    }
+    if (!$imageUrl && $imageKey && !empty($row[$imageKey])) {
+        $imageUrl = (string) $row[$imageKey];
+    }
+
+    return [
+        'Id' => $id,
+        'Codigo' => $codeKey && isset($row[$codeKey]) ? (string) $row[$codeKey] : null,
+        'Nombre' => $nameKey && isset($row[$nameKey]) ? (string) $row[$nameKey] : null,
+        'Precio' => $price,
+        'Stock' => $stock,
+        'Activo' => $active,
+        'Categoria' => $categoryKey && isset($row[$categoryKey]) ? (string) $row[$categoryKey] : null,
+        'Material' => $materialKey && isset($row[$materialKey]) ? (string) $row[$materialKey] : null,
+        'ImagenUrl' => $imageUrl,
+        'Descripcion' => $descriptionKey && isset($row[$descriptionKey]) ? (string) $row[$descriptionKey] : null,
+    ];
+}
+
+function fetch_product_row(PDO $pdo, array $productSchema, array $imageSchema, int $id): ?array
+{
+    $columns = ['p.' . $productSchema['id'] . ' AS __id'];
+    foreach (['code', 'name', 'price', 'stock', 'active', 'category', 'material', 'image', 'description'] as $key) {
+        if (!empty($productSchema[$key])) {
+            $columns[] = 'p.' . $productSchema[$key] . ' AS ' . $productSchema[$key];
+        }
+    }
+
+    $sql = 'SELECT ' . implode(', ', $columns) . ' FROM ' . $productSchema['table'] . ' p WHERE p.' . $productSchema['id'] . ' = :id LIMIT 1';
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([':id' => $id]);
+    $row = $stmt->fetch();
+    if (!$row) {
+        return null;
+    }
+
+    $imageRow = null;
+    if (!empty($imageSchema['table'])) {
+        $sqlImg = 'SELECT ' . $imageSchema['id'] . ' AS imagen_id, ' . $imageSchema['url'] . ' AS url, ' . $imageSchema['blob'] . ' AS blob, ' . $imageSchema['mime'] . ' AS mime
+                   FROM ' . $imageSchema['table'] . '
+                   WHERE ' . $imageSchema['product_fk'] . ' = :id
+                   ORDER BY ' . $imageSchema['id'] . ' ASC
+                   LIMIT 1';
+        $stmtImg = $pdo->prepare($sqlImg);
+        $stmtImg->execute([':id' => $id]);
+        $imageRow = $stmtImg->fetch();
+    }
+
+    $mapped = map_product_row($row, $productSchema, $imageRow ?: null);
+    if ($imageRow && isset($imageRow['imagen_id'])) {
+        $mapped['ImagenId'] = (int) $imageRow['imagen_id'];
+    }
+    return $mapped;
+}
+
+function fetch_products(PDO $pdo, array $productSchema, array $imageSchema): array
+{
+    $columns = ['p.' . $productSchema['id'] . ' AS __id'];
+    foreach (['code', 'name', 'price', 'stock', 'active', 'category', 'material', 'image', 'description'] as $key) {
+        if (!empty($productSchema[$key])) {
+            $columns[] = 'p.' . $productSchema[$key] . ' AS ' . $productSchema[$key];
+        }
+    }
+
+    $sql = 'SELECT ' . implode(', ', $columns) . ' FROM ' . $productSchema['table'] . ' p ORDER BY p.' . $productSchema['id'] . ' DESC';
+    $rows = $pdo->query($sql)->fetchAll();
+    if (!$rows) {
+        return [];
+    }
+
+    $imageMap = [];
+    if (!empty($imageSchema['table'])) {
+        $ids = array_column($rows, '__id');
+        $placeholders = [];
+        $params = [];
+        foreach ($ids as $index => $value) {
+            $ph = ':id' . $index;
+            $placeholders[] = $ph;
+            $params[$ph] = $value;
+        }
+        $sqlImg = 'SELECT ' . $imageSchema['product_fk'] . ' AS product_id, ' . $imageSchema['id'] . ' AS imagen_id, ' . $imageSchema['url'] . ' AS url, ' . $imageSchema['blob'] . ' AS blob, ' . $imageSchema['mime'] . ' AS mime
+                   FROM ' . $imageSchema['table'];
+        if ($placeholders) {
+            $sqlImg .= ' WHERE ' . $imageSchema['product_fk'] . ' IN (' . implode(', ', $placeholders) . ')';
+        }
+        $sqlImg .= ' ORDER BY ' . $imageSchema['id'] . ' ASC';
+        $stmtImg = $pdo->prepare($sqlImg);
+        $stmtImg->execute($params);
+        while ($img = $stmtImg->fetch()) {
+            $pid = (int) $img['product_id'];
+            if (!isset($imageMap[$pid])) {
+                $imageMap[$pid] = $img;
+            }
+        }
+    }
+
+    $products = [];
+    foreach ($rows as $row) {
+        $id = isset($row['__id']) ? (int) $row['__id'] : null;
+        $mapped = map_product_row($row, $productSchema, $id && isset($imageMap[$id]) ? $imageMap[$id] : null);
+        if ($id && isset($imageMap[$id]['imagen_id'])) {
+            $mapped['ImagenId'] = (int) $imageMap[$id]['imagen_id'];
+        }
+        $products[] = $mapped;
+    }
+
+    return $products;
+}
+
+function extract_field(array $payload, array $keys, $default = null)
+{
+    foreach ($keys as $key) {
+        if (array_key_exists($key, $payload)) {
+            return $payload[$key];
+        }
+    }
+    return $default;
+}
+
+function normalize_string($value): ?string
+{
+    if ($value === null) {
+        return null;
+    }
+    $text = trim((string) $value);
+    return $text === '' ? null : $text;
+}
+
+function normalize_numeric($value, bool $allowNull = true): ?float
+{
+    if ($value === null || $value === '') {
+        return $allowNull ? null : 0.0;
+    }
+    if (is_numeric($value)) {
+        return (float) $value;
+    }
+    $filtered = preg_replace('/[^0-9.\-]/', '', (string) $value);
+    if ($filtered === '' || !is_numeric($filtered)) {
+        return $allowNull ? null : 0.0;
+    }
+    return (float) $filtered;
+}
+
+function normalize_int($value, bool $allowNull = true): ?int
+{
+    if ($value === null || $value === '') {
+        return $allowNull ? null : 0;
+    }
+    if (is_numeric($value)) {
+        return (int) $value;
+    }
+    $filtered = preg_replace('/[^0-9\-]/', '', (string) $value);
+    if ($filtered === '' || !is_numeric($filtered)) {
+        return $allowNull ? null : 0;
+    }
+    return (int) $filtered;
+}
+
+function normalize_bool_flag($value): int
+{
+    if ($value === null) {
+        return 0;
+    }
+    if (is_bool($value)) {
+        return $value ? 1 : 0;
+    }
+    if (is_numeric($value)) {
+        return (int) $value ? 1 : 0;
+    }
+    $text = strtolower(trim((string) $value));
+    return in_array($text, ['1', 'true', 'activo', 'habilitado', 'disponible', 'yes', 'si', 'on'], true) ? 1 : 0;
+}

--- a/api/products.php
+++ b/api/products.php
@@ -1,0 +1,194 @@
+<?php
+declare(strict_types=1);
+
+header('Content-Type: application/json; charset=utf-8');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With');
+header('Access-Control-Max-Age: 86400');
+
+require __DIR__ . '/db.php';
+require __DIR__ . '/products-lib.php';
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+if ($method === 'OPTIONS') {
+    respond_json(204);
+}
+
+try {
+    $productSchema = ensure_products_schema($pdo);
+    $imageSchema = ensure_images_schema($pdo, $productSchema);
+} catch (Throwable $e) {
+    respond_error(500, 'No se pudo preparar el servicio de productos.', ['detail' => $e->getMessage()]);
+}
+
+function build_product_fields(array $payload, array $productSchema): array
+{
+    $fields = [];
+
+    $code = normalize_string(extract_field($payload, ['Codigo', 'codigo', 'SKU', 'sku', 'clave', 'code']));
+    if ($code !== null && !empty($productSchema['code'])) {
+        $fields[$productSchema['code']] = $code;
+    }
+
+    $name = normalize_string(extract_field($payload, ['Nombre', 'nombre', 'name', 'Titulo', 'titulo', 'descripcion', 'Descripcion']));
+    if ($name !== null && !empty($productSchema['name'])) {
+        $fields[$productSchema['name']] = $name;
+    }
+
+    $priceValue = extract_field($payload, ['Precio', 'precio', 'price', 'costo']);
+    $price = normalize_numeric($priceValue, false);
+    if ($price !== null && !empty($productSchema['price'])) {
+        $fields[$productSchema['price']] = $price;
+    }
+
+    $stockValue = extract_field($payload, ['Stock', 'stock', 'existencia', 'cantidad']);
+    $stock = normalize_int($stockValue, false);
+    if ($stock !== null && !empty($productSchema['stock'])) {
+        $fields[$productSchema['stock']] = $stock;
+    }
+
+    $activeValue = extract_field($payload, ['Activo', 'activo', 'estado', 'estatus', 'habilitado']);
+    if (!empty($productSchema['active'])) {
+        $fields[$productSchema['active']] = normalize_bool_flag($activeValue);
+    }
+
+    $category = normalize_string(extract_field($payload, ['Categoria', 'categoria', 'category']));
+    if ($category !== null && !empty($productSchema['category'])) {
+        $fields[$productSchema['category']] = $category;
+    }
+
+    $material = normalize_string(extract_field($payload, ['Material', 'material']));
+    if ($material !== null && !empty($productSchema['material'])) {
+        $fields[$productSchema['material']] = $material;
+    }
+
+    $image = extract_field($payload, ['ImagenUrl', 'imagenUrl', 'imagenurl', 'image', 'imageUrl', 'url_imagen']);
+    if ($image !== null && !empty($productSchema['image'])) {
+        $fields[$productSchema['image']] = normalize_string($image);
+    }
+
+    $description = normalize_string(extract_field($payload, ['Descripcion', 'descripcion', 'detalle', 'detalleProducto']));
+    if ($description !== null && !empty($productSchema['description'])) {
+        $fields[$productSchema['description']] = $description;
+    }
+
+    return $fields;
+}
+
+function insert_product(PDO $pdo, array $productSchema, array $fields): int
+{
+    if (!$fields) {
+        respond_error(422, 'No se enviaron campos para crear el producto.');
+    }
+
+    $columns = [];
+    $placeholders = [];
+    $params = [];
+    $index = 0;
+    foreach ($fields as $column => $value) {
+        $columns[] = $column;
+        $placeholder = ':p' . $index++;
+        $placeholders[] = $placeholder;
+        $params[$placeholder] = $value;
+    }
+
+    $sql = 'INSERT INTO ' . $productSchema['table'] . ' (' . implode(', ', $columns) . ')
+            VALUES (' . implode(', ', $placeholders) . ')';
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
+
+    return (int) $pdo->lastInsertId();
+}
+
+function update_product(PDO $pdo, array $productSchema, int $id, array $fields): void
+{
+    if (!$fields) {
+        respond_error(422, 'No se enviaron cambios para actualizar.');
+    }
+
+    $sets = [];
+    $params = [];
+    $index = 0;
+    foreach ($fields as $column => $value) {
+        $placeholder = ':p' . $index++;
+        $sets[] = $column . ' = ' . $placeholder;
+        $params[$placeholder] = $value;
+    }
+    $params[':id'] = $id;
+
+    $sql = 'UPDATE ' . $productSchema['table'] . ' SET ' . implode(', ', $sets) . ' WHERE ' . $productSchema['id'] . ' = :id';
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
+}
+
+function delete_product(PDO $pdo, array $productSchema, array $imageSchema, int $id): void
+{
+    $pdo->beginTransaction();
+    try {
+        if (!empty($imageSchema['table'])) {
+            $stmt = $pdo->prepare('DELETE FROM ' . $imageSchema['table'] . ' WHERE ' . $imageSchema['product_fk'] . ' = :id');
+            $stmt->execute([':id' => $id]);
+        }
+        $stmt = $pdo->prepare('DELETE FROM ' . $productSchema['table'] . ' WHERE ' . $productSchema['id'] . ' = :id');
+        $stmt->execute([':id' => $id]);
+        $pdo->commit();
+    } catch (Throwable $e) {
+        $pdo->rollBack();
+        throw $e;
+    }
+}
+
+$id = isset($_GET['id']) ? (int) $_GET['id'] : null;
+
+try {
+    switch ($method) {
+        case 'GET':
+            if ($id) {
+                $product = fetch_product_row($pdo, $productSchema, $imageSchema, $id);
+                if (!$product) {
+                    respond_error(404, 'Producto no encontrado.');
+                }
+                respond_json(200, ['ok' => true, 'product' => $product]);
+            }
+            $list = fetch_products($pdo, $productSchema, $imageSchema);
+            respond_json(200, ['ok' => true, 'count' => count($list), 'products' => $list]);
+
+        case 'POST':
+            $payload = read_json_input();
+            $fields = build_product_fields($payload, $productSchema);
+            if (!empty($productSchema['name']) && !array_key_exists($productSchema['name'], $fields)) {
+                respond_error(422, 'El nombre del producto es obligatorio.');
+            }
+            $id = insert_product($pdo, $productSchema, $fields);
+            $product = fetch_product_row($pdo, $productSchema, $imageSchema, $id);
+            respond_json(201, ['ok' => true, 'product' => $product]);
+
+        case 'PUT':
+        case 'PATCH':
+            if (!$id) {
+                respond_error(400, 'Falta el identificador del producto.');
+            }
+            $payload = read_json_input();
+            $fields = build_product_fields($payload, $productSchema);
+            update_product($pdo, $productSchema, $id, $fields);
+            $product = fetch_product_row($pdo, $productSchema, $imageSchema, $id);
+            respond_json(200, ['ok' => true, 'product' => $product]);
+
+        case 'DELETE':
+            if (!$id) {
+                respond_error(400, 'Falta el identificador del producto.');
+            }
+            delete_product($pdo, $productSchema, $imageSchema, $id);
+            respond_json(200, ['ok' => true]);
+
+        default:
+            respond_error(405, 'Método no permitido.');
+    }
+} catch (InvalidArgumentException $e) {
+    respond_error(422, $e->getMessage());
+} catch (RuntimeException $e) {
+    respond_error(404, $e->getMessage());
+} catch (Throwable $e) {
+    respond_error(500, 'Ocurrió un error al procesar la solicitud de productos.', ['detail' => $e->getMessage()]);
+}


### PR DESCRIPTION
## Summary
- add PHP helpers and endpoints to list, mutate, and upload product data directly against the local database
- expose a categories endpoint and adjust shared API utilities and authentication to use the local login and product services
- rebuild the vendor sales dashboard to fetch and update orders from the PHP API while keeping the admin catalog tools in sync with the new endpoints

## Testing
- php -l api/products-lib.php
- php -l api/products.php
- php -l api/product-image.php
- php -l api/categories.php

------
https://chatgpt.com/codex/tasks/task_e_68ec2d1f0fb88325aabf03b926fddd98